### PR TITLE
Add support for basic filter modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `OR` and `AND` modes for filtering
+- Allow filter mode override for specific conditions
 
 ## [0.3.1] - 2020-08-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `OR` and `AND` modes for filtering
-- Allow filter mode override for specific conditions
+- Added `or` and `and` modes for filtering
+- The `AddCondition` event now supports an optional `mode`, defaulting to `or`
+
+### Changed
+- **Breaking:** `activeConditions` is now `activeOrConditions`
+  - This mainly affects the `ConditionsInitialized` state of the `FilterConditionsBloc`
 
 ## [0.3.1] - 2020-08-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2020-09-27
 ### Added
 - Added `or` and `and` modes for filtering
 - The `AddCondition` event now supports an optional `mode`, defaulting to `or`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.4.0] - 2020-09-27
+
 ### Added
 - Added `or` and `and` modes for filtering
 - The `AddCondition` event now supports an optional `mode`, defaulting to `or`
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This mainly affects the `ConditionsInitialized` state of the `FilterConditionsBloc`
 
 ## [0.3.1] - 2020-08-08
+
 ### Fixed
 - Corrected outdated `SearchQueryBloc` documentation
 
@@ -23,12 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `blocTest` and `whenListen` typing
 
 ## [0.3.0] - 2020-08-08
+
 ### Changed
 - **Breaking:** `SearchQueryBloc` is now `SearchQueryCubit`
   - The `SetSearchQuery` event is now the `setQuery` method
   - The `ClearSearchQuery` event is now the `clearQuery` method
 
 ## [0.2.0] - 2020-07-28
+
 ### Added
 - Changelog documentation
 
@@ -36,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Abandoned Dart pre-1.0 semver designations. Bumping the package to account for the minor version bump that should have happened with the addition of boolean value support in 0.1.4.
 
 ## [0.1.5] - 2020-07-27
+
 Previously released as 0.1.4+1
 
 ### Changed
@@ -46,10 +51,12 @@ Previously released as 0.1.4+1
 - Moved over to the more accepted pre-1.0 semver designations
 
 ## [0.1.4] - 2020-07-26
+
 ### Added
 - Boolean value support for automatic filter condition generation as well as while filtering the source list via https://github.com/danahartweg/flutter_bloc_list_manager/issues/8
 
 ## [0.1.3] - 2020-07-21
+
 ### Changed
 - Bumped `bloc` to `^5.0.0`
 - Bumped `flutter_bloc` to `^5.0.0`
@@ -57,16 +64,19 @@ Previously released as 0.1.4+1
 - Updated bloc testing mechanisms to conform to the new `whenListen` behavior that also stubs the state when called: https://github.com/felangel/bloc/pull/1133
 
 ## [0.1.2] - 2020-04-24
+
 ### Changed
 - Bumped `bloc` to `^4.0.0`
 - Bumped `flutter_bloc` to `^4.0.0`
 - Bumped `bloc_test` to `^5.0.0`
 
 ## [0.1.1] - 2020-04-12
+
 ### Changed
 - Documentation updates
 
 ## [0.1.0] - 2020-04-12
+
 Initial package implementation and testing.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ context.bloc<SearchQueryCubit>().clearQuery();
 
 `ItemListBloc` is responsible for connecting all of the other blocs, performing the actual filtering and searching, and providing state in order to render your list UI. There is never a reason to dispatch events to this bloc.
 
+_Note on filter modes_
+Without a much more sophisticated means to assemble filter queries, there is no current way to support compound filtering: i.e. `(Condition 1 AND Condition 2) OR (Condition 3 AND Condition 4)` or priority scenarios: i.e. the difference between `(Condition 1 OR Condition 2 OR Condition 3) AND Condition 4` and `Condition 4 AND (Condition 1 OR Condition 2 OR Condition 3)`. As such, we've chosen to implement filtering such that additive (`or`) conditions are matched first and subtractive (`and`) conditions are matched last.
+
+Practically, what does this mean?
+
+Your list of items will first be filtered such that *every item* matching *any* single `or` condition is sent through. The resulting list will then be filtered such that *every item* matching *all* `and` conditions are sent through. The `and` conditions technically refine the resulting list and the `or` conditions generate the first pass of the list that should be refined.
+
 _Example_
 
 ```dart

--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ The `ListManager` widget is the entry-point to accessing the blocs provided by t
 `ListManager` should be established with:
 
 _Types_
-+ `I` - the [item class](#ItemClassWithAccessor) holding the data for the list
-+ `T` - the [state](#ItemSourceState) containing the loaded items
-+ `B` - the bloc that contains the above state
+
+- `I` - the [item class](#ItemClassWithAccessor) holding the data for the list
+- `T` - the [state](#ItemSourceState) containing the loaded items
+- `B` - the bloc that contains the above state
 
 _Parameters_
-+ `filterProperties` - properties that exist on your item class `I` that should be used to generate filter conditions
-+ `searchProperties` - properties that exist on your item class `I` that should be used to run search queries against
-+ `child` - the widget to be rendered by the `ListManager`, which will have access to the remaining blocs
+
+- `filterProperties` - properties that exist on your item class `I` that should be used to generate filter conditions
+- `searchProperties` - properties that exist on your item class `I` that should be used to run search queries against
+- `child` - the widget to be rendered by the `ListManager`, which will have access to the remaining blocs
 
 _Example_
+
 ```dart
 BlocProvider<SourceBloc>(
   create: (_) => SourceBloc(),
@@ -65,6 +68,7 @@ String values are treated normally.
 Boolean values are treated a little differently. If a boolean value is requested to be used as a `filterCondition`, display-friendly `True` and `False` conditions will automatically be added for you.
 
 _Example_
+
 ```dart
 BlocBuilder<FilterConditionsBloc, FilterConditionsState>(
   builder: (_, state) {
@@ -90,21 +94,46 @@ BlocBuilder<FilterConditionsBloc, FilterConditionsState>(
 )
 ```
 
+#### Dispatching events
+
 Events can be dispatched against the `FilterConditionsBloc` to add/remove active property/value condition pairs. Whenever the source bloc is updated, active conditions that no longer apply are automatically removed.
 
 _Example_
+
 ```dart
-context.bloc<FilterConditionsBloc>().add(AddCondition('property', 'value'));
-context.bloc<FilterConditionsBloc>().add(RemoveCondition('property', 'value'));
+context.bloc<FilterConditionsBloc>().add(AddCondition(
+  property: 'property',
+  value: 'value',
+));
+
+context.bloc<FilterConditionsBloc>().add(RemoveCondition(
+  property: 'property',
+  value: 'value',
+));
 ```
 
 Note: If you want to manually toggle a boolean condition (i.e. not via constructing UI from the `availableConditions`), you would want to use `AddCondition('booleanProperty', 'True')` or `AddCondition('booleanProperty', 'False')` as those are the underlying display values.
 
-### SearchQueryCubit
+#### Filter modes
 
-The simplest bloc of the bunch, the `SearchQueryCubit` is solely responsible for setting or clearing the search query that drives list searching.
+You can choose to override the default filter mode when adding a specific condition for filtering. Perhaps you'd like the main filtering UI to be additive, but you would like to add a global toggle to add and remove a subtractive filter condition into the mix.
 
 _Example_
+
+```dart
+context.bloc<FilterConditionsBloc>().add(AddCondition(
+  property: 'property',
+  value: 'value',
+  mode: FilterMode.and,
+));
+```
+
+### SearchQueryCubit
+
+The simplest cubit of the bunch, the `SearchQueryCubit` is solely responsible for setting or clearing the search query that drives list searching.
+
+_Example_
+
 ```dart
 context.bloc<SearchQueryCubit>().setQuery('query');
 context.bloc<SearchQueryCubit>().clearQuery();
@@ -115,6 +144,7 @@ context.bloc<SearchQueryCubit>().clearQuery();
 `ItemListBloc` is responsible for connecting all of the other blocs, performing the actual filtering and searching, and providing state in order to render your list UI. There is never a reason to dispatch events to this bloc.
 
 _Example_
+
 ```dart
 BlocBuilder<ItemListBloc, ItemListState>(
   builder: (_, state) {
@@ -187,6 +217,7 @@ class ItemClass extends Equatable implements ItemClassWithAccessor {
 You are free to manage your source bloc however you see fit. The only requirement in order to instantiate a `ListManager` is that one of the states of your source bloc must implement `ItemSourceState`. This allows blocs in this package to know when source items are actually flowing through your source bloc.
 
 _Example_
+
 ```dart
 class SourceLoaded extends SourceBlocState implements ItemSourceState<ItemClass> {
   final items;
@@ -200,10 +231,10 @@ class SourceLoaded extends SourceBlocState implements ItemSourceState<ItemClass>
 
 ## Upcoming improvements
 
-+ Pluggable search callback (allowing integration of fuzzy search)
-+ Conditional instantiation of the `SearchQueryCubit`
-+ Integrating opinionated pre-composed UI widgets
-+ Potentially moving away from the source bloc concept and requiring a repository instead
+- Pluggable search callback (allowing integration of fuzzy search)
+- Conditional instantiation of the `SearchQueryCubit`
+- Integrating opinionated pre-composed UI widgets
+- Potentially moving away from the source bloc concept and requiring a repository instead
 
 ## Examples
 

--- a/lib/src/filter_conditions/filter_conditions_bloc.dart
+++ b/lib/src/filter_conditions/filter_conditions_bloc.dart
@@ -104,6 +104,9 @@ class FilterConditionsBloc<T extends ItemSourceState>
             availableConditions[property].toSet().toList()..sort();
       }
 
+      _conditionKeyTracker
+          .removeWhere((key, _) => !availableConditionKeys.contains(key));
+
       add(RefreshConditions(
         activeAndConditions:
             activeAndConditions.intersection(availableConditionKeys),
@@ -165,7 +168,6 @@ class FilterConditionsBloc<T extends ItemSourceState>
     }
 
     _conditionKeyTracker[conditionKey] = event.mode;
-
     return ConditionsInitialized(
       activeAndConditions: activeAndConditions,
       activeOrConditions: activeOrConditions,
@@ -203,6 +205,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
         break;
     }
 
+    _conditionKeyTracker.remove(conditionKey);
     return ConditionsInitialized(
       activeAndConditions: activeAndConditions,
       activeOrConditions: activeOrConditions,
@@ -221,13 +224,8 @@ class FilterConditionsBloc<T extends ItemSourceState>
   /// Helper that checks whether a [value] for a given [property] exists in
   /// the current state as an active condition.
   bool isConditionActive(String property, String value) {
-    final currentState = state;
     final conditionKey = generateConditionKey(property, value);
-
-    return currentState is ConditionsInitialized
-        ? currentState.activeAndConditions.contains(conditionKey) ||
-            currentState.activeOrConditions.contains(conditionKey)
-        : false;
+    return _conditionKeyTracker.containsKey(conditionKey);
   }
 
   @override

--- a/lib/src/filter_conditions/filter_conditions_event.dart
+++ b/lib/src/filter_conditions/filter_conditions_event.dart
@@ -10,8 +10,8 @@ abstract class FilterConditionsEvent extends Equatable {
 
 /// {@template refreshconditions}
 /// Dispatched whenever the source bloc receives new state.
-/// [availableConditions] entries are regenerated and
-/// [activeConditions] that still have a corresponding entry
+/// [availableConditions] entries are regenerated and [activeAndConditions]
+/// and [activeOrConditions] that still have a corresponding entry
 /// in the regenerated [availableConditions] are maintained.
 /// {@endtemplate}
 class RefreshConditions extends FilterConditionsEvent {
@@ -20,15 +20,28 @@ class RefreshConditions extends FilterConditionsEvent {
   final Map<String, List<String>> availableConditions;
 
   /// Any property/value pairs (in the format `$property::$value`)
-  /// that are currently being used to filter items from the source bloc.
-  final Set<String> activeConditions;
+  /// that are currently being used to filter items from the source bloc
+  /// using the `and` mode.
+  final Set<String> activeAndConditions;
+
+  /// Any property/value pairs (in the format `$property::$value`)
+  /// that are currently being used to filter items from the source bloc
+  /// using the `or` mode.
+  final Set<String> activeOrConditions;
 
   /// {@macro refreshconditions}
-  const RefreshConditions(
-      {@required this.availableConditions, @required this.activeConditions});
+  const RefreshConditions({
+    @required this.availableConditions,
+    @required this.activeAndConditions,
+    @required this.activeOrConditions,
+  });
 
   @override
-  List<Object> get props => [availableConditions, activeConditions];
+  List<Object> get props => [
+        availableConditions,
+        activeAndConditions,
+        activeOrConditions,
+      ];
 }
 
 /// {@template addcondition}
@@ -43,11 +56,17 @@ class AddCondition extends FilterConditionsEvent {
   /// The value to be added.
   final String value;
 
+  final FilterMode mode;
+
   /// {@macro addcondition}
-  const AddCondition({@required this.property, @required this.value});
+  const AddCondition({
+    @required this.property,
+    @required this.value,
+    this.mode = FilterMode.or,
+  });
 
   @override
-  List<Object> get props => [property, value];
+  List<Object> get props => [property, value, mode];
 }
 
 /// {@template removecondition}
@@ -63,7 +82,10 @@ class RemoveCondition extends FilterConditionsEvent {
   final String value;
 
   /// {@macro removecondition}
-  const RemoveCondition({@required this.property, @required this.value});
+  const RemoveCondition({
+    @required this.property,
+    @required this.value,
+  });
 
   @override
   List<Object> get props => [property, value];

--- a/lib/src/filter_conditions/filter_conditions_event.dart
+++ b/lib/src/filter_conditions/filter_conditions_event.dart
@@ -56,6 +56,7 @@ class AddCondition extends FilterConditionsEvent {
   /// The value to be added.
   final String value;
 
+  /// The filter mode to use for this condition.
   final FilterMode mode;
 
   /// {@macro addcondition}

--- a/lib/src/filter_conditions/filter_conditions_state.dart
+++ b/lib/src/filter_conditions/filter_conditions_state.dart
@@ -32,15 +32,28 @@ class ConditionsInitialized extends FilterConditionsState {
   final Map<String, List<String>> availableConditions;
 
   /// Any `property::value` pairs that are currently being
-  /// used to filter items from the source bloc.
+  /// used to filter items from the source bloc using the `and` mode.
   ///
   /// There should be no need to interact directly with this state property.
-  final Set<String> activeConditions;
+  final Set<String> activeAndConditions;
+
+  /// Any `property::value` pairs that are currently being
+  /// used to filter items from the source bloc using the `or` mode.
+  ///
+  /// There should be no need to interact directly with this state property.
+  final Set<String> activeOrConditions;
 
   /// {@macro conditionsinitialized}
-  const ConditionsInitialized(
-      {@required this.availableConditions, @required this.activeConditions});
+  const ConditionsInitialized({
+    @required this.availableConditions,
+    @required this.activeAndConditions,
+    @required this.activeOrConditions,
+  });
 
   @override
-  List<Object> get props => [availableConditions, activeConditions];
+  List<Object> get props => [
+        availableConditions,
+        activeAndConditions,
+        activeOrConditions,
+      ];
 }

--- a/lib/src/item_list/item_list_bloc.dart
+++ b/lib/src/item_list/item_list_bloc.dart
@@ -97,28 +97,53 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
   }
 
   Iterable<I> _filterSource(List<I> items) {
-    final activeOrConditions =
-        (_filterConditionsBloc.state as ConditionsInitialized)
-            .activeOrConditions;
+    final filterState = (_filterConditionsBloc.state as ConditionsInitialized);
+    final activeAndConditions = filterState.activeAndConditions;
+    final activeOrConditions = filterState.activeOrConditions;
 
-    if (activeOrConditions.isEmpty) {
+    if (activeAndConditions.isEmpty && activeOrConditions.isEmpty) {
       return items;
     }
 
-    // If any active condition matches we can immediately return that item.
-    return items.where((item) => activeOrConditions.any((conditionKey) {
-          final parsedConditionKey = splitConditionKey(conditionKey);
+    return items.where((item) {
+      final hasMatchedOrConditions = activeOrConditions.isEmpty
+          ? true
+          : activeOrConditions.any((conditionKey) {
+              final parsedConditionKey = splitConditionKey(conditionKey);
 
-          final property = parsedConditionKey[0];
-          final itemValue = item[property];
-          final targetValue = parsedConditionKey[1];
+              final property = parsedConditionKey[0];
+              final itemValue = item[property];
+              final targetValue = parsedConditionKey[1];
 
-          if (itemValue is bool) {
-            return itemValue.toString() == targetValue.toLowerCase();
-          }
+              if (itemValue is bool) {
+                return itemValue.toString() == targetValue.toLowerCase();
+              }
 
-          return itemValue == targetValue;
-        }));
+              return itemValue == targetValue;
+            });
+
+      if (!hasMatchedOrConditions) {
+        return false;
+      }
+
+      final hasMatchedAndConditions = activeAndConditions.isEmpty
+          ? true
+          : activeAndConditions.every((conditionKey) {
+              final parsedConditionKey = splitConditionKey(conditionKey);
+
+              final property = parsedConditionKey[0];
+              final itemValue = item[property];
+              final targetValue = parsedConditionKey[1];
+
+              if (itemValue is bool) {
+                return itemValue.toString() == targetValue.toLowerCase();
+              }
+
+              return itemValue == targetValue;
+            });
+
+      return hasMatchedAndConditions && hasMatchedOrConditions;
+    });
   }
 
   Iterable<I> _searchSource(String searchQuery, Iterable<I> items) {

--- a/lib/src/item_list/item_list_bloc.dart
+++ b/lib/src/item_list/item_list_bloc.dart
@@ -108,19 +108,8 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
     return items.where((item) {
       final hasMatchedOrConditions = activeOrConditions.isEmpty
           ? true
-          : activeOrConditions.any((conditionKey) {
-              final parsedConditionKey = splitConditionKey(conditionKey);
-
-              final property = parsedConditionKey[0];
-              final itemValue = item[property];
-              final targetValue = parsedConditionKey[1];
-
-              if (itemValue is bool) {
-                return itemValue.toString() == targetValue.toLowerCase();
-              }
-
-              return itemValue == targetValue;
-            });
+          : activeOrConditions.any(
+              (conditionKey) => _evaluateFilterCondition(item, conditionKey));
 
       if (!hasMatchedOrConditions) {
         return false;
@@ -128,19 +117,8 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
 
       final hasMatchedAndConditions = activeAndConditions.isEmpty
           ? true
-          : activeAndConditions.every((conditionKey) {
-              final parsedConditionKey = splitConditionKey(conditionKey);
-
-              final property = parsedConditionKey[0];
-              final itemValue = item[property];
-              final targetValue = parsedConditionKey[1];
-
-              if (itemValue is bool) {
-                return itemValue.toString() == targetValue.toLowerCase();
-              }
-
-              return itemValue == targetValue;
-            });
+          : activeAndConditions.every(
+              (conditionKey) => _evaluateFilterCondition(item, conditionKey));
 
       return hasMatchedAndConditions && hasMatchedOrConditions;
     });
@@ -159,6 +137,20 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
               ? value.toLowerCase().contains(searchQuery)
               : false;
         }));
+  }
+
+  bool _evaluateFilterCondition(I item, String conditionKey) {
+    final parsedConditionKey = splitConditionKey(conditionKey);
+
+    final property = parsedConditionKey[0];
+    final itemValue = item[property];
+    final targetValue = parsedConditionKey[1];
+
+    if (itemValue is bool) {
+      return itemValue.toString() == targetValue.toLowerCase();
+    }
+
+    return itemValue == targetValue;
   }
 
   @override

--- a/lib/src/item_list/item_list_bloc.dart
+++ b/lib/src/item_list/item_list_bloc.dart
@@ -97,15 +97,16 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
   }
 
   Iterable<I> _filterSource(List<I> items) {
-    final activeConditions =
-        (_filterConditionsBloc.state as ConditionsInitialized).activeConditions;
+    final activeOrConditions =
+        (_filterConditionsBloc.state as ConditionsInitialized)
+            .activeOrConditions;
 
-    if (activeConditions.isEmpty) {
+    if (activeOrConditions.isEmpty) {
       return items;
     }
 
     // If any active condition matches we can immediately return that item.
-    return items.where((item) => activeConditions.any((conditionKey) {
+    return items.where((item) => activeOrConditions.any((conditionKey) {
           final parsedConditionKey = splitConditionKey(conditionKey);
 
           final property = parsedConditionKey[0];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_bloc_list_manager
-version: 0.3.1
+version: 0.4.0
 description: >
   Extension to flutter_bloc that handles the underlying logic to filter and search list view data dynamically.
 homepage: https://github.com/danahartweg/flutter_bloc_list_manager

--- a/test/filter_conditions_bloc_test.dart
+++ b/test/filter_conditions_bloc_test.dart
@@ -605,6 +605,70 @@ void main() {
       );
     });
 
+    test('returns whether a condition is active or not', () async {
+      final bloc = FilterConditionsBloc(
+        sourceBloc: _sourceBloc,
+        filterProperties: [],
+      )..emit(ConditionsInitialized(
+          activeAndConditions: {},
+          activeOrConditions: {},
+          availableConditions: {},
+        ));
+
+      expect(bloc.isConditionActive('nothing', 'here'), false);
+
+      bloc.add(AddCondition(
+        property: 'id',
+        value: '123',
+      ));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('id', '123'), true);
+
+      bloc.add(AddCondition(
+        property: 'extra',
+        value: 'something',
+        mode: FilterMode.and,
+      ));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('extra', 'something'), true);
+
+      bloc.add(RemoveCondition(
+        property: 'id',
+        value: '123',
+      ));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('id', '123'), false);
+
+      bloc.add(RemoveCondition(
+        property: 'extra',
+        value: 'something',
+      ));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('extra', 'something'), false);
+    });
+
+    test('keeps active conditions up to date if the source changes', () async {
+      final bloc = FilterConditionsBloc(
+        sourceBloc: _sourceBloc,
+        filterProperties: [],
+      )..emit(ConditionsInitialized(
+          activeAndConditions: {},
+          activeOrConditions: {},
+          availableConditions: {},
+        ));
+
+      bloc.add(AddCondition(
+        property: 'id',
+        value: '123',
+      ));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('id', '123'), true);
+
+      _sourceStreamController.add(MockSourceBlocClassItems([]));
+      await Future.delayed(Duration());
+      expect(bloc.isConditionActive('id', '123'), false);
+    });
+
     test('closes the source bloc subscription', () {
       final stream = Stream.value(MockSourceBlocNoItems()).asBroadcastStream();
       final onDoneCallback = expectAsync0(() {});

--- a/test/filter_conditions_bloc_test.dart
+++ b/test/filter_conditions_bloc_test.dart
@@ -86,7 +86,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {},
           )
         ],
@@ -107,7 +108,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
@@ -137,7 +139,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'name': [],
               'extra': [],
@@ -162,7 +165,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
               'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
@@ -189,14 +193,16 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
             },
           ),
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem2.id, _mockItem3.id],
               'extra': [_mockItem2.extra, _mockItem3.extra],
@@ -218,8 +224,18 @@ void main() {
           bloc.add(AddCondition(property: 'id', value: _mockItem1.id));
           await Future.delayed(Duration());
 
-          _sourceStreamController
-              .add(MockSourceBlocClassItems([_mockItem1, _mockItem2]));
+          bloc.add(AddCondition(
+            property: 'id',
+            value: _mockItem3.id,
+            mode: FilterMode.and,
+          ));
+          await Future.delayed(Duration());
+
+          _sourceStreamController.add(MockSourceBlocClassItems([
+            _mockItem1,
+            _mockItem2,
+            _mockItem3,
+          ]));
           await Future.delayed(Duration());
 
           _sourceStreamController.add(MockSourceBlocClassItems([_mockItem2]));
@@ -227,14 +243,16 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
             },
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', _mockItem1.id),
             },
             availableConditions: {
@@ -243,16 +261,40 @@ void main() {
             },
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {
+              generateConditionKey('id', _mockItem3.id),
+            },
+            activeOrConditions: {
               generateConditionKey('id', _mockItem1.id),
             },
             availableConditions: {
-              'id': [_mockItem1.id, _mockItem2.id],
-              'extra': [_mockItem1.extra, _mockItem2.extra],
+              'id': [_mockItem1.id],
+              'extra': [_mockItem1.extra],
             },
           ),
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {
+              generateConditionKey('id', _mockItem3.id),
+            },
+            activeOrConditions: {
+              generateConditionKey('id', _mockItem1.id),
+            },
+            availableConditions: {
+              'id': [
+                _mockItem1.id,
+                _mockItem2.id,
+                _mockItem3.id,
+              ],
+              'extra': [
+                _mockItem1.extra,
+                _mockItem2.extra,
+                _mockItem3.extra,
+              ],
+            },
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem2.id],
               'extra': [_mockItem2.extra],
@@ -277,7 +319,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id],
               'extra': [_mockItem1.extra, _mockItem2.extra],
@@ -302,7 +345,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
               'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
@@ -327,7 +371,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'conditional': [
                 'True',
@@ -353,7 +398,8 @@ void main() {
         },
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {
               'conditional': [
                 'True',
@@ -383,7 +429,8 @@ void main() {
           filterProperties: [],
         )..emit(ConditionsInitialized(
             availableConditions: {},
-            activeConditions: {},
+            activeOrConditions: {},
+            activeAndConditions: {},
           )),
         act: (bloc) => bloc
           ..add(AddCondition(property: 'id', value: '123'))
@@ -398,20 +445,23 @@ void main() {
           ..add(RemoveCondition(property: 'extra', value: 'something')),
         expect: [
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '123'),
             },
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('extra', 'something'),
             },
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
@@ -419,7 +469,8 @@ void main() {
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
@@ -428,7 +479,8 @@ void main() {
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
@@ -439,7 +491,8 @@ void main() {
           ),
           // Conditions start to be removed.
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
@@ -448,7 +501,8 @@ void main() {
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
@@ -456,20 +510,95 @@ void main() {
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
             },
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{
+            activeAndConditions: {},
+            activeOrConditions: {
               generateConditionKey('extra', 'something'),
             },
             availableConditions: {},
           ),
           ConditionsInitialized(
-            activeConditions: <String>{},
+            activeAndConditions: {},
+            activeOrConditions: {},
+            availableConditions: {},
+          ),
+        ],
+      );
+
+      blocTest<FilterConditionsBloc, FilterConditionsState>(
+        'adds and removes active conditions across filter modes',
+        build: () => FilterConditionsBloc<MockSourceBlocClassItems>(
+          sourceBloc: _sourceBloc,
+          filterProperties: [],
+        )..emit(ConditionsInitialized(
+            activeAndConditions: {},
+            activeOrConditions: {},
+            availableConditions: {},
+          )),
+        act: (bloc) => bloc
+          ..add(AddCondition(property: 'id', value: '123'))
+          ..add(AddCondition(
+            property: 'id',
+            value: '123',
+            mode: FilterMode.and,
+          ))
+          ..add(AddCondition(
+            property: 'extra',
+            value: 'something',
+            mode: FilterMode.and,
+          ))
+          ..add(AddCondition(property: 'extra', value: 'something'))
+          ..add(RemoveCondition(property: 'extra', value: 'something'))
+          ..add(RemoveCondition(property: 'id', value: '123')),
+        expect: [
+          ConditionsInitialized(
+            activeAndConditions: {},
+            activeOrConditions: {
+              generateConditionKey('id', '123'),
+            },
+            availableConditions: {},
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {
+              generateConditionKey('id', '123'),
+            },
+            activeOrConditions: {},
+            availableConditions: {},
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {
+              generateConditionKey('id', '123'),
+              generateConditionKey('extra', 'something'),
+            },
+            activeOrConditions: {},
+            availableConditions: {},
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {
+              generateConditionKey('id', '123'),
+            },
+            activeOrConditions: {
+              generateConditionKey('extra', 'something'),
+            },
+            availableConditions: {},
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {
+              generateConditionKey('id', '123'),
+            },
+            activeOrConditions: {},
+            availableConditions: {},
+          ),
+          ConditionsInitialized(
+            activeAndConditions: {},
+            activeOrConditions: {},
             availableConditions: {},
           ),
         ],

--- a/test/item_list_bloc_test.dart
+++ b/test/item_list_bloc_test.dart
@@ -17,18 +17,21 @@ void main() {
     id: 'idValue1',
     name: 'nameValue1',
     extra: 'extraValue1',
+    common: 'first',
     conditional: true,
   );
   const _mockItem2 = MockItemClass(
     id: 'idValue2',
     name: 'nameValue2',
     extra: 'extraValue2',
+    common: 'first',
     conditional: false,
   );
   const _mockItem3 = MockItemClass(
     id: 'idValue3',
     name: 'nameValue3',
     extra: 'extraValue3',
+    common: 'value2',
     conditional: true,
   );
 
@@ -122,12 +125,12 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem1])
+        ItemResults([_mockItem1]),
       ],
     );
 
     blocTest<ItemListBloc, ItemListState>(
-      'sets filter empty state with no source items matching active conditions',
+      'sets filter empty state with no source items matching "or" conditions',
       build: () {
         whenListen<FilterConditionsState>(
           _filterConditionsBloc,
@@ -155,11 +158,13 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [ItemEmptyState()],
+      expect: [
+        ItemEmptyState(),
+      ],
     );
 
     blocTest<ItemListBloc, ItemListState>(
-      'returns source items matching a single active condition key',
+      'returns source items matching a single active "or" condition',
       build: () {
         whenListen<FilterConditionsState>(
           _filterConditionsBloc,
@@ -189,7 +194,115 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem1, _mockItem3])
+        ItemResults([_mockItem1, _mockItem3]),
+      ],
+    );
+
+    blocTest<ItemListBloc, ItemListState>(
+      // ignore: lines_longer_than_80_chars
+      'sets filter empty state with no source items matching both "and" conditions',
+      build: () {
+        whenListen<FilterConditionsState>(
+          _filterConditionsBloc,
+          Stream.value(
+            ConditionsInitialized(
+              activeAndConditions: {
+                generateConditionKey('id', _mockItem1.id),
+                generateConditionKey('name', 'bogus name'),
+              },
+              activeOrConditions: {},
+              availableConditions: {},
+            ),
+          ),
+        );
+        whenListen<String>(_searchQueryCubit, Stream.value(''));
+        whenListen<MockSourceBlocState>(
+          _sourceBloc,
+          Stream.value(
+            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+          ),
+        );
+
+        return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
+          filterConditionsBloc: _filterConditionsBloc,
+          searchQueryCubit: _searchQueryCubit,
+          sourceBloc: _sourceBloc,
+        );
+      },
+      expect: [
+        ItemEmptyState(),
+      ],
+    );
+
+    blocTest<ItemListBloc, ItemListState>(
+      'returns source items matching both active "and" conditions',
+      build: () {
+        whenListen<FilterConditionsState>(
+          _filterConditionsBloc,
+          Stream.value(
+            ConditionsInitialized(
+              activeAndConditions: {
+                generateConditionKey('id', _mockItem1.id),
+                generateConditionKey('common', _mockItem2.common),
+              },
+              activeOrConditions: {},
+              availableConditions: {},
+            ),
+          ),
+        );
+        whenListen<String>(_searchQueryCubit, Stream.value(''));
+        whenListen<MockSourceBlocState>(
+          _sourceBloc,
+          Stream.value(
+            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+          ),
+        );
+
+        return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
+          filterConditionsBloc: _filterConditionsBloc,
+          searchQueryCubit: _searchQueryCubit,
+          sourceBloc: _sourceBloc,
+        );
+      },
+      expect: [
+        ItemResults([_mockItem1]),
+      ],
+    );
+
+    blocTest<ItemListBloc, ItemListState>(
+      'returns source items matching active "and" and "or" conditions',
+      build: () {
+        whenListen<FilterConditionsState>(
+          _filterConditionsBloc,
+          Stream.value(
+            ConditionsInitialized(
+              activeAndConditions: {
+                generateConditionKey('common', _mockItem2.common),
+              },
+              activeOrConditions: {
+                generateConditionKey('id', _mockItem1.id),
+                generateConditionKey('id', _mockItem3.id),
+              },
+              availableConditions: {},
+            ),
+          ),
+        );
+        whenListen<String>(_searchQueryCubit, Stream.value(''));
+        whenListen<MockSourceBlocState>(
+          _sourceBloc,
+          Stream.value(
+            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+          ),
+        );
+
+        return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
+          filterConditionsBloc: _filterConditionsBloc,
+          searchQueryCubit: _searchQueryCubit,
+          sourceBloc: _sourceBloc,
+        );
+      },
+      expect: [
+        ItemResults([_mockItem1]),
       ],
     );
 
@@ -223,7 +336,7 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem1, _mockItem3])
+        ItemResults([_mockItem1, _mockItem3]),
       ],
     );
 
@@ -258,7 +371,7 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem1, _mockItem3])
+        ItemResults([_mockItem1, _mockItem3]),
       ],
     );
 
@@ -291,7 +404,7 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem2])
+        ItemResults([_mockItem2]),
       ],
     );
 
@@ -328,7 +441,47 @@ void main() {
         );
       },
       expect: [
-        ItemResults([_mockItem2])
+        ItemResults([_mockItem2]),
+      ],
+    );
+
+    blocTest<ItemListBloc, ItemListState>(
+      // ignore: lines_longer_than_80_chars
+      'returns source items matching a query after filtering active "and" and "or" conditions',
+      build: () {
+        whenListen<FilterConditionsState>(
+          _filterConditionsBloc,
+          Stream.value(
+            ConditionsInitialized(
+              activeAndConditions: {
+                generateConditionKey('common', _mockItem1.common),
+              },
+              activeOrConditions: {
+                generateConditionKey('id', _mockItem1.id),
+                generateConditionKey('id', _mockItem2.id),
+                generateConditionKey('id', _mockItem3.id),
+              },
+              availableConditions: {},
+            ),
+          ),
+        );
+        whenListen<String>(_searchQueryCubit, Stream.value('value2'));
+        whenListen<MockSourceBlocState>(
+          _sourceBloc,
+          Stream.value(
+            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+          ),
+        );
+
+        return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
+          filterConditionsBloc: _filterConditionsBloc,
+          searchQueryCubit: _searchQueryCubit,
+          sourceBloc: _sourceBloc,
+          searchProperties: ['extra'],
+        );
+      },
+      expect: [
+        ItemResults([_mockItem2]),
       ],
     );
 
@@ -364,7 +517,9 @@ void main() {
           searchProperties: ['extra'],
         );
       },
-      expect: [ItemEmptyState()],
+      expect: [
+        ItemEmptyState(),
+      ],
     );
   });
 }

--- a/test/item_list_bloc_test.dart
+++ b/test/item_list_bloc_test.dart
@@ -78,7 +78,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{},
+              activeAndConditions: {},
+              activeOrConditions: {},
               availableConditions: {},
             ),
           ),
@@ -102,7 +103,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{},
+              activeAndConditions: {},
+              activeOrConditions: {},
               availableConditions: {},
             ),
           ),
@@ -131,7 +133,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('id', '123'),
               },
               availableConditions: {},
@@ -162,7 +165,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem3.id),
               },
@@ -196,7 +200,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('conditional', 'True'),
               },
               availableConditions: {},
@@ -229,7 +234,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('conditional', 'True'),
               },
@@ -263,7 +269,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{},
+              activeAndConditions: {},
+              activeOrConditions: {},
               availableConditions: {},
             ),
           ),
@@ -295,7 +302,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem2.id),
                 generateConditionKey('id', _mockItem3.id),
@@ -331,7 +339,8 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeConditions: <String>{
+              activeAndConditions: {},
+              activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem2.id),
                 generateConditionKey('id', _mockItem3.id),

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -22,12 +22,14 @@ class MockItemClass extends Equatable implements ItemClassWithAccessor {
   final String id;
   final String name;
   final String extra;
+  final String common;
   final bool conditional;
 
   const MockItemClass({
     this.id,
     this.name,
     this.extra,
+    this.common,
     this.conditional,
   });
 
@@ -42,6 +44,9 @@ class MockItemClass extends Equatable implements ItemClassWithAccessor {
       case 'extra':
         return extra;
         break;
+      case 'common':
+        return common;
+        break;
       case 'conditional':
         return conditional;
         break;
@@ -53,7 +58,7 @@ class MockItemClass extends Equatable implements ItemClassWithAccessor {
   }
 
   @override
-  List<Object> get props => [id, name, extra, conditional];
+  List<Object> get props => [id, name, extra, common, conditional];
 }
 
 class MockSourceBlocClassItems extends MockSourceBlocState


### PR DESCRIPTION
I initially considered adding a `defaultFilterMode` property to the `FilterConditionsBloc`, but ultimately decided against that. The way filtering is implemented for now, it makes the most sense for `or` conditions to be the default. Plus, it's easy enough to adjust the filter mode when adding a new condition.

**Note:** See the filtering methodology section of the readme: https://github.com/danahartweg/flutter_bloc_list_manager/pull/21/files#diff-04c6e90faac2675aa89e2176d2eec7d8R146

Closes #5 