### PR TITLE
Update packages and migrate to null safety

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1.3.2
+      - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "1.17.x"
+          flutter-version: "2.8.x"
           channel: "stable"
 
       - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
         run: flutter test --no-pub --coverage --test-randomize-ordering-seed random
 
       - name: Code coverage
-        uses: ChicagoFlutter/lcov-cop@v1.0.2
+        uses: VeryGoodOpenSource/very_good_coverage@v1.2.0
         with:
           min_coverage: 75
 

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1.3.2
+      - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "1.17.x"
+          flutter-version: "2.8.x"
           channel: "stable"
 
       - name: Parse local version
@@ -33,7 +33,7 @@ jobs:
       - name: Parse changelog
         if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.version }}
         id: changelog
-        uses: mindsers/changelog-reader-action@v1.3.1
+        uses: mindsers/changelog-reader-action@v2
         with:
           version: v${{ steps.local_version.outputs.version }}
           path: ./CHANGELOG.md
@@ -48,7 +48,7 @@ jobs:
         with:
           tag_name: v${{ steps.local_version.outputs.version }}
           release_name: v${{ steps.local_version.outputs.version }}
-          body: ${{ steps.changelog.outputs.log_entry }}
+          body: ${{ steps.changelog.outputs.changes }}
 
       - name: Publish
         if: ${{ steps.local_version.outputs.version != steps.remote_version.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2022-01-28
+
+### Changed
+- **Breaking:** Converted to null safety.
+- Bumped `bloc` to `^8.0.2`
+- Bumped `bloc_test` to `^9.0.2`
+- Bumped `equatable` to `^2.0.3`
+- Bumped `flutter_bloc` to `^8.0.1`
+
 ## [0.4.0] - 2020-09-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0] - 2022-01-28
+## [0.5.0] - 2022-01-29
 
 ### Changed
-- **Breaking:** Converted to null safety.
+- **Breaking:** Migrated to null safety.
 - Bumped `bloc` to `^8.0.2`
-- Bumped `bloc_test` to `^9.0.2`
 - Bumped `equatable` to `^2.0.3`
 - Bumped `flutter_bloc` to `^8.0.1`
 

--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ Events can be dispatched against the `FilterConditionsBloc` to add/remove active
 _Example_
 
 ```dart
-context.bloc<FilterConditionsBloc>().add(AddCondition(
+context.read<FilterConditionsBloc>().add(AddCondition(
   property: 'property',
   value: 'value',
 ));
 
-context.bloc<FilterConditionsBloc>().add(RemoveCondition(
+context.read<FilterConditionsBloc>().add(RemoveCondition(
   property: 'property',
   value: 'value',
 ));
@@ -121,7 +121,7 @@ You can choose to override the default filter mode when adding a specific condit
 _Example_
 
 ```dart
-context.bloc<FilterConditionsBloc>().add(AddCondition(
+context.read<FilterConditionsBloc>().add(AddCondition(
   property: 'property',
   value: 'value',
   mode: FilterMode.and,
@@ -135,8 +135,8 @@ The simplest cubit of the bunch, the `SearchQueryCubit` is solely responsible fo
 _Example_
 
 ```dart
-context.bloc<SearchQueryCubit>().setQuery('query');
-context.bloc<SearchQueryCubit>().clearQuery();
+context.read<SearchQueryCubit>().setQuery('query');
+context.read<SearchQueryCubit>().clearQuery();
 ```
 
 ### ItemListBloc

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
 analyzer:
   exclude:
-    - example/*
-
-include: package:effective_dart/analysis_options.1.2.0.yaml
+    - example/**

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,13 +4,217 @@
 // UI for managing the filter conditions.
 
 import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
-import 'package:flutter/material.dart';
 
 // Data, state, and event classes.
 
 // Base data class that will be supplied by the source bloc.
+void main() {
+  runApp(
+    // Provide our source bloc to the remainder of the tree. In an actual app,
+    // this would happen much close to where it was needed.
+    BlocProvider<JournalEntryBloc>(
+      create: (_) => JournalEntryBloc()..add(_journalEntryEvent.load),
+      child: MaterialApp(
+        title: 'Flutter Bloc List Manager',
+        home: Scaffold(
+          appBar: AppBar(
+            title: Text('Flutter Bloc List Manager'),
+          ),
+          body: ListManager<JournalEntry, Loaded, JournalEntryBloc>(
+            filterProperties: ['author', 'category', 'isPublished'],
+            searchProperties: ['content', 'description', 'title'],
+            child: Column(
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    SearchInput(),
+                    FilterConditionsLauncher(),
+                  ],
+                ),
+                SizedBox(height: 10.0),
+                Expanded(
+                  child: ItemListRenderer(),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+// The base state for the source bloc.
+const _filterPropertyLabelMap = {
+  'author': 'Author',
+  'category': 'Category',
+  'isPublished': 'Published',
+};
+
+// State of the source bloc where items have not yet been loaded.
+class FilterConditionGroup extends StatelessWidget {
+  final MapEntry<String, List<String>> condition;
+  final Function(String property, String value) isOptionActive;
+  final Function updateCondition;
+
+  FilterConditionGroup({
+    Key key,
+    @required this.condition,
+    @required this.isOptionActive,
+    @required this.updateCondition,
+  }) : super(key: key);
+
+  @override
+  Widget build(_) {
+    return Container(
+      key: ValueKey(condition.key),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            _filterPropertyLabelMap[condition.key],
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          ...condition.value.map(
+            (option) => CheckboxListTile(
+              key: ValueKey(option),
+              title: Text(option),
+              value: isOptionActive(condition.key, option),
+              controlAffinity: ListTileControlAffinity.leading,
+              onChanged: (isChecked) =>
+                  updateCondition(condition.key, option, isChecked),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// State of the source bloc that indicates items have been loaded
+// and are ready for further processing.
+class FilterConditionsLauncher extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(Icons.filter_list),
+      onPressed: () {
+        showModalBottomSheet(
+          context: context,
+          builder: (_) => FilterConditionsSheet(
+            filterConditionsBloc: context.read<FilterConditionsBloc>(),
+          ),
+          elevation: 1,
+        );
+      },
+    );
+  }
+}
+
+// Just a stub event for example purposes.
+// Your actual source bloc would have more logic.
+class FilterConditionsSheet extends StatelessWidget {
+  // You must pass the FilterConditionsBloc to this widget, as the build
+  // context will now belong to the Scaffold rendering the bottom sheet.
+  final FilterConditionsBloc _filterConditionsBloc;
+
+  const FilterConditionsSheet({@required filterConditionsBloc})
+      : assert(filterConditionsBloc != null),
+        _filterConditionsBloc = filterConditionsBloc;
+
+  // Helper to avoid duplication in the child components and to avoid
+  // having to pass the bloc down another level.
+  // Handles toggling property/value pair in the filter conditions bloc.
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: MediaQuery.of(context).size.height * 0.3,
+      child: BlocBuilder<FilterConditionsBloc, FilterConditionsState>(
+        bloc: _filterConditionsBloc,
+        builder: (_, state) {
+          if (state is ConditionsInitialized) {
+            // This could be further optimized by removing
+            // the `FilterConditionGroup` all together and conditionally
+            // rendering title or option rows.
+            return ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: state.availableConditions.length,
+              itemBuilder: (_, index) {
+                final condition =
+                    state.availableConditions.entries.elementAt(index);
+                return FilterConditionGroup(
+                  condition: condition,
+                  isOptionActive: _isOptionActive,
+                  updateCondition: _updateCondition,
+                );
+              },
+            );
+          }
+
+          return CircularProgressIndicator();
+        },
+      ),
+    );
+  }
+
+  bool _isOptionActive(String property, String value) {
+    return _filterConditionsBloc.isConditionActive(property, value);
+  }
+
+  void _updateCondition(String property, String value, bool isChecked) {
+    isChecked
+        ? _filterConditionsBloc.add(AddCondition(
+            property: property,
+            value: value,
+          ))
+        : _filterConditionsBloc.add(RemoveCondition(
+            property: property,
+            value: value,
+          ));
+  }
+}
+
+class ItemListRenderer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ItemListBloc, ItemListState>(
+      builder: (_, state) {
+        if (state is NoSourceItems) {
+          return Text('No source items');
+        }
+
+        if (state is ItemEmptyState) {
+          return Text('No matching results');
+        }
+
+        if (state is ItemResults<JournalEntry>) {
+          return ListView(
+            children: state.items
+                .map(
+                  (entry) => ListTile(
+                    key: ValueKey(entry.id),
+                    title: Text(entry.title),
+                    subtitle: Text(entry.description),
+                  ),
+                )
+                .toList(),
+          );
+        }
+
+        return Container();
+      },
+    );
+  }
+}
+
 class JournalEntry extends Equatable implements ItemClassWithAccessor {
   final String author;
   final String category;
@@ -32,6 +236,10 @@ class JournalEntry extends Equatable implements ItemClassWithAccessor {
 
   // Every prop intended to be used in a filtering or sorting operation
   // should be included in this operator overload.
+  @override
+  List<Object> get props =>
+      [author, content, description, id, title, isPublished];
+
   dynamic operator [](String prop) {
     switch (prop) {
       case 'author':
@@ -56,39 +264,9 @@ class JournalEntry extends Equatable implements ItemClassWithAccessor {
         throw ArgumentError('Property `$prop` does not exist on JournalEntry.');
     }
   }
-
-  @override
-  List<Object> get props =>
-      [author, content, description, id, title, isPublished];
 }
 
-// The base state for the source bloc.
-abstract class JournalEntryState extends Equatable {
-  const JournalEntryState();
-}
-
-// State of the source bloc where items have not yet been loaded.
-class Loading extends JournalEntryState {
-  @override
-  List<Object> get props => ['Loading'];
-}
-
-// State of the source bloc that indicates items have been loaded
-// and are ready for further processing.
-class Loaded extends JournalEntryState
-    implements ItemSourceState<JournalEntry> {
-  final List<JournalEntry> items;
-
-  const Loaded(this.items);
-
-  @override
-  List<Object> get props => [items];
-}
-
-// Just a stub event for example purposes.
-// Your actual source bloc would have more logic.
-enum _journalEntryEvent { load }
-
+// Render an input that will funnel the value into the SearchQueryCubit.
 class JournalEntryBloc extends Bloc<_journalEntryEvent, JournalEntryState> {
   JournalEntryBloc() : super(Loading());
 
@@ -132,45 +310,33 @@ class JournalEntryBloc extends Bloc<_journalEntryEvent, JournalEntryState> {
   }
 }
 
-void main() {
-  runApp(
-    // Provide our source bloc to the remainder of the tree. In an actual app,
-    // this would happen much close to where it was needed.
-    BlocProvider<JournalEntryBloc>(
-      create: (_) => JournalEntryBloc()..add(_journalEntryEvent.load),
-      child: MaterialApp(
-        title: 'Flutter Bloc List Manager',
-        home: Scaffold(
-          appBar: AppBar(
-            title: Text('Flutter Bloc List Manager'),
-          ),
-          body: ListManager<JournalEntry, Loaded, JournalEntryBloc>(
-            filterProperties: ['author', 'category', 'isPublished'],
-            searchProperties: ['content', 'description', 'title'],
-            child: Column(
-              children: [
-                Row(
-                  mainAxisSize: MainAxisSize.max,
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    SearchInput(),
-                    FilterConditionsLauncher(),
-                  ],
-                ),
-                SizedBox(height: 10.0),
-                Expanded(
-                  child: ItemListRenderer(),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    ),
-  );
+// Render an icon button that will launch the filter conditions UI sheet
+// into the current scaffold.
+abstract class JournalEntryState extends Equatable {
+  const JournalEntryState();
 }
 
-// Render an input that will funnel the value into the SearchQueryCubit.
+// Hooks into the `FilterConditionsBloc` in order to render the filtering UI.
+class Loaded extends JournalEntryState
+    implements ItemSourceState<JournalEntry> {
+  final List<JournalEntry> items;
+
+  const Loaded(this.items);
+
+  @override
+  List<Object> get props => [items];
+}
+
+// As we've built a UI around filtering, we need display-friendly
+// labels for the underlying property names.
+// This could easily be provided statically by the base item class instead.
+class Loading extends JournalEntryState {
+  @override
+  List<Object> get props => ['Loading'];
+}
+
+// Essentially just a pass-through widget to simplify the rendering
+// of each condition group.
 class SearchInput extends StatelessWidget {
   @override
   Widget build(_) {
@@ -192,172 +358,6 @@ class SearchInput extends StatelessWidget {
   }
 }
 
-// Render an icon button that will launch the filter conditions UI sheet
-// into the current scaffold.
-class FilterConditionsLauncher extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return IconButton(
-      icon: Icon(Icons.filter_list),
-      onPressed: () {
-        showModalBottomSheet(
-          context: context,
-          builder: (_) => FilterConditionsSheet(
-            filterConditionsBloc: context.read<FilterConditionsBloc>(),
-          ),
-          elevation: 1,
-        );
-      },
-    );
-  }
-}
-
-// Hooks into the `FilterConditionsBloc` in order to render the filtering UI.
-class FilterConditionsSheet extends StatelessWidget {
-  // You must pass the FilterConditionsBloc to this widget, as the build
-  // context will now belong to the Scaffold rendering the bottom sheet.
-  final FilterConditionsBloc _filterConditionsBloc;
-
-  const FilterConditionsSheet({@required filterConditionsBloc})
-      : assert(filterConditionsBloc != null),
-        _filterConditionsBloc = filterConditionsBloc;
-
-  // Helper to avoid duplication in the child components and to avoid
-  // having to pass the bloc down another level.
-  // Handles toggling property/value pair in the filter conditions bloc.
-  void _updateCondition(String property, String value, bool isChecked) {
-    isChecked
-        ? _filterConditionsBloc.add(AddCondition(
-            property: property,
-            value: value,
-          ))
-        : _filterConditionsBloc.add(RemoveCondition(
-            property: property,
-            value: value,
-          ));
-  }
-
-  bool _isOptionActive(String property, String value) {
-    return _filterConditionsBloc.isConditionActive(property, value);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      height: MediaQuery.of(context).size.height * 0.3,
-      child: BlocBuilder<FilterConditionsBloc, FilterConditionsState>(
-        bloc: _filterConditionsBloc,
-        builder: (_, state) {
-          if (state is ConditionsInitialized) {
-            // This could be further optimized by removing
-            // the `FilterConditionGroup` all together and conditionally
-            // rendering title or option rows.
-            return ListView.builder(
-              padding: const EdgeInsets.all(8),
-              itemCount: state.availableConditions.length,
-              itemBuilder: (_, index) {
-                final condition =
-                    state.availableConditions.entries.elementAt(index);
-                return FilterConditionGroup(
-                  condition: condition,
-                  isOptionActive: _isOptionActive,
-                  updateCondition: _updateCondition,
-                );
-              },
-            );
-          }
-
-          return CircularProgressIndicator();
-        },
-      ),
-    );
-  }
-}
-
-// As we've built a UI around filtering, we need display-friendly
-// labels for the underlying property names.
-// This could easily be provided statically by the base item class instead.
-const _filterPropertyLabelMap = {
-  'author': 'Author',
-  'category': 'Category',
-  'isPublished': 'Published',
-};
-
-// Essentially just a pass-through widget to simplify the rendering
-// of each condition group.
-class FilterConditionGroup extends StatelessWidget {
-  final MapEntry<String, List<String>> condition;
-  final Function(String property, String value) isOptionActive;
-  final Function updateCondition;
-
-  FilterConditionGroup({
-    Key key,
-    @required this.condition,
-    @required this.isOptionActive,
-    @required this.updateCondition,
-  }) : super(key: key);
-
-  @override
-  Widget build(_) {
-    return Container(
-      key: ValueKey(condition.key),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            _filterPropertyLabelMap[condition.key],
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          ...condition.value.map(
-            (option) => CheckboxListTile(
-              key: ValueKey(option),
-              title: Text(option),
-              value: isOptionActive(condition.key, option),
-              controlAffinity: ListTileControlAffinity.leading,
-              onChanged: (isChecked) =>
-                  updateCondition(condition.key, option, isChecked),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
 // Hooks into the state from the `ItemListBloc` and renders the list
 // portion of the UI.
-class ItemListRenderer extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return BlocBuilder<ItemListBloc, ItemListState>(
-      builder: (_, state) {
-        if (state is NoSourceItems) {
-          return Text('No source items');
-        }
-
-        if (state is ItemEmptyState) {
-          return Text('No matching results');
-        }
-
-        if (state is ItemResults<JournalEntry>) {
-          return ListView(
-            children: state.items
-                .map(
-                  (entry) => ListTile(
-                    key: ValueKey(entry.id),
-                    title: Text(entry.title),
-                    subtitle: Text(entry.description),
-                  ),
-                )
-                .toList(),
-          );
-        }
-
-        return Container();
-      },
-    );
-  }
-}
+enum _journalEntryEvent { load }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,10 +63,10 @@ class FilterConditionGroup extends StatelessWidget {
   final Function updateCondition;
 
   FilterConditionGroup({
+    required this.condition,
+    required this.isOptionActive,
+    required this.updateCondition,
     Key key,
-    @required this.condition,
-    @required this.isOptionActive,
-    @required this.updateCondition,
   }) : super(key: key);
 
   @override
@@ -126,7 +126,7 @@ class FilterConditionsSheet extends StatelessWidget {
   // context will now belong to the Scaffold rendering the bottom sheet.
   final FilterConditionsBloc _filterConditionsBloc;
 
-  const FilterConditionsSheet({@required filterConditionsBloc})
+  const FilterConditionsSheet({required filterConditionsBloc})
       : assert(filterConditionsBloc != null),
         _filterConditionsBloc = filterConditionsBloc;
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -184,7 +184,7 @@ class SearchInput extends StatelessWidget {
             ),
             textInputAction: TextInputAction.search,
             onChanged: (value) =>
-                context.bloc<SearchQueryCubit>().setQuery(value),
+                context.read<SearchQueryCubit>().setQuery(value),
           ),
         );
       },
@@ -203,7 +203,7 @@ class FilterConditionsLauncher extends StatelessWidget {
         showModalBottomSheet(
           context: context,
           builder: (_) => FilterConditionsSheet(
-            filterConditionsBloc: context.bloc<FilterConditionsBloc>(),
+            filterConditionsBloc: context.read<FilterConditionsBloc>(),
           ),
           elevation: 1,
         );
@@ -246,7 +246,7 @@ class FilterConditionsSheet extends StatelessWidget {
     return Container(
       height: MediaQuery.of(context).size.height * 0.3,
       child: BlocBuilder<FilterConditionsBloc, FilterConditionsState>(
-        cubit: _filterConditionsBloc,
+        bloc: _filterConditionsBloc,
         builder: (_, state) {
           if (state is ConditionsInitialized) {
             // This could be further optimized by removing

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -8,13 +8,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "5.0.1"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
   cubit:
     dependency: transitive
     description:
@@ -61,7 +68,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.7.0"
   nested:
     dependency: transitive
     description:
@@ -87,14 +94,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.16.0"

--- a/lib/src/filter_conditions/filter_conditions_bloc.dart
+++ b/lib/src/filter_conditions/filter_conditions_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:meta/meta.dart';
 
 import '../item_source.dart';
 import '../utils.dart';
@@ -27,16 +26,14 @@ class FilterConditionsBloc<T extends ItemSourceState>
   final List<String> _filterProperties;
   final Bloc _sourceBloc;
 
-  StreamSubscription _sourceSubscription;
+  late StreamSubscription _sourceSubscription;
   final Map<String, FilterMode> _conditionKeyTracker = {};
 
   /// {@macro filterconditionsbloc}
   FilterConditionsBloc({
-    @required List<String> filterProperties,
-    @required Bloc sourceBloc,
-  })  : assert(filterProperties != null),
-        assert(sourceBloc != null),
-        _filterProperties = filterProperties,
+    required List<String> filterProperties,
+    required Bloc sourceBloc,
+  })  : _filterProperties = filterProperties,
         _sourceBloc = sourceBloc,
         super(const ConditionsUninitialized()) {
     _sourceSubscription = _sourceBloc.stream.listen((sourceState) {
@@ -57,8 +54,8 @@ class FilterConditionsBloc<T extends ItemSourceState>
           if (value is bool) {
             booleanProperties.add(property);
 
-            availableConditions[property].add('True');
-            availableConditions[property].add('False');
+            availableConditions[property]!.add('True');
+            availableConditions[property]!.add('False');
 
             availableConditionKeys.add(generateConditionKey(property, 'True'));
             availableConditionKeys.add(generateConditionKey(property, 'False'));
@@ -67,7 +64,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
           if (value is String && value.isNotEmpty) {
             final conditionKey = generateConditionKey(property, value);
 
-            availableConditions[property].add(value);
+            availableConditions[property]!.add(value);
             availableConditionKeys.add(conditionKey);
           }
         }
@@ -92,7 +89,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
         // Ensure only unique entries are present and that entries are sorted.
         // Removing duplicates before sorting will save a few cycles.
         availableConditions[property] =
-            availableConditions[property].toSet().toList()..sort();
+            availableConditions[property]!.toSet().toList()..sort();
       }
 
       _conditionKeyTracker
@@ -121,7 +118,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
 
   @override
   Future<void> close() async {
-    await _sourceSubscription?.cancel();
+    await _sourceSubscription.cancel();
     return super.close();
   }
 
@@ -174,7 +171,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
   }
 
   Map<String, List<String>> _generateFilterPropertiesMap() {
-    return { for (var item in _filterProperties) item : [] };
+    return {for (var item in _filterProperties) item: []};
   }
 
   FilterConditionsState _removeConditionFromActiveConditions(

--- a/lib/src/filter_conditions/filter_conditions_bloc.dart
+++ b/lib/src/filter_conditions/filter_conditions_bloc.dart
@@ -48,7 +48,7 @@ class FilterConditionsBloc<T extends ItemSourceState>
         _filterProperties = filterProperties,
         _sourceBloc = sourceBloc,
         super(ConditionsUninitialized()) {
-    _sourceSubscription = _sourceBloc.listen((sourceState) {
+    _sourceSubscription = _sourceBloc.stream.listen((sourceState) {
       if (sourceState is! T) {
         return;
       }
@@ -115,23 +115,17 @@ class FilterConditionsBloc<T extends ItemSourceState>
         availableConditions: availableConditions,
       ));
     });
-  }
 
-  @override
-  Stream<FilterConditionsState> mapEventToState(
-    FilterConditionsEvent event,
-  ) async* {
-    if (event is RefreshConditions) {
-      yield ConditionsInitialized(
-        activeAndConditions: event.activeAndConditions,
-        activeOrConditions: event.activeOrConditions,
-        availableConditions: event.availableConditions,
-      );
-    } else if (event is AddCondition) {
-      yield _addConditionToActiveConditions(event);
-    } else if (event is RemoveCondition) {
-      yield _removeConditionFromActiveConditions(event);
-    }
+    on<RefreshConditions>((event, emit) => emit(ConditionsInitialized(
+          activeAndConditions: event.activeAndConditions,
+          activeOrConditions: event.activeOrConditions,
+          availableConditions: event.availableConditions,
+        )));
+
+    on<AddCondition>(
+        (event, emit) => emit(_addConditionToActiveConditions(event)));
+    on<RemoveCondition>(
+        (event, emit) => emit(_removeConditionFromActiveConditions(event)));
   }
 
   FilterConditionsState _addConditionToActiveConditions(

--- a/lib/src/filter_conditions/filter_conditions_event.dart
+++ b/lib/src/filter_conditions/filter_conditions_event.dart
@@ -1,5 +1,31 @@
 part of 'filter_conditions_bloc.dart';
 
+/// {@template addcondition}
+/// Dispatched to add the requested [property] [value] pair to the list
+/// of conditions that are currently active.
+/// {@endtemplate}
+class AddCondition extends FilterConditionsEvent {
+  /// The [property] identifier containing the [value],
+  /// matching a filter property supplied to the `FilterConditionsBloc`.
+  final String property;
+
+  /// The value to be added.
+  final String value;
+
+  /// The filter mode to use for this condition.
+  final FilterMode mode;
+
+  /// {@macro addcondition}
+  const AddCondition({
+    @required this.property,
+    @required this.value,
+    this.mode = FilterMode.or,
+  });
+
+  @override
+  List<Object> get props => [property, value, mode];
+}
+
 /// {@template filterconditionsevent}
 /// Base [FilterConditionsEvent] for extension.
 /// {@endtemplate}
@@ -42,32 +68,6 @@ class RefreshConditions extends FilterConditionsEvent {
         activeAndConditions,
         activeOrConditions,
       ];
-}
-
-/// {@template addcondition}
-/// Dispatched to add the requested [property] [value] pair to the list
-/// of conditions that are currently active.
-/// {@endtemplate}
-class AddCondition extends FilterConditionsEvent {
-  /// The [property] identifier containing the [value],
-  /// matching a filter property supplied to the `FilterConditionsBloc`.
-  final String property;
-
-  /// The value to be added.
-  final String value;
-
-  /// The filter mode to use for this condition.
-  final FilterMode mode;
-
-  /// {@macro addcondition}
-  const AddCondition({
-    @required this.property,
-    @required this.value,
-    this.mode = FilterMode.or,
-  });
-
-  @override
-  List<Object> get props => [property, value, mode];
 }
 
 /// {@template removecondition}

--- a/lib/src/filter_conditions/filter_conditions_event.dart
+++ b/lib/src/filter_conditions/filter_conditions_event.dart
@@ -17,8 +17,8 @@ class AddCondition extends FilterConditionsEvent {
 
   /// {@macro addcondition}
   const AddCondition({
-    @required this.property,
-    @required this.value,
+    required this.property,
+    required this.value,
     this.mode = FilterMode.or,
   });
 
@@ -57,9 +57,9 @@ class RefreshConditions extends FilterConditionsEvent {
 
   /// {@macro refreshconditions}
   const RefreshConditions({
-    @required this.availableConditions,
-    @required this.activeAndConditions,
-    @required this.activeOrConditions,
+    required this.availableConditions,
+    required this.activeAndConditions,
+    required this.activeOrConditions,
   });
 
   @override
@@ -84,8 +84,8 @@ class RemoveCondition extends FilterConditionsEvent {
 
   /// {@macro removecondition}
   const RemoveCondition({
-    @required this.property,
-    @required this.value,
+    required this.property,
+    required this.value,
   });
 
   @override

--- a/lib/src/filter_conditions/filter_conditions_state.dart
+++ b/lib/src/filter_conditions/filter_conditions_state.dart
@@ -1,26 +1,5 @@
 part of 'filter_conditions_bloc.dart';
 
-/// {@template filterconditionsstate}
-/// Base [FilterConditionsState] for extension.
-/// {@endtemplate}
-abstract class FilterConditionsState extends Equatable {
-  /// {@macro filterconditionsstate}
-  const FilterConditionsState();
-}
-
-/// {@template conditionsuninitialized}
-/// State when available conditions have yet to be generated.
-/// This will generally happen if the source bloc has not yet
-/// emitted a state containing items to process.
-/// {@endtemplate}
-class ConditionsUninitialized extends FilterConditionsState {
-  /// {@macro conditionsuninitialized}
-  const ConditionsUninitialized();
-
-  @override
-  List<Object> get props => ['Uninitialized'];
-}
-
 /// {@template conditionsinitialized}
 /// {@endtemplate}
 class ConditionsInitialized extends FilterConditionsState {
@@ -56,4 +35,25 @@ class ConditionsInitialized extends FilterConditionsState {
         activeAndConditions,
         activeOrConditions,
       ];
+}
+
+/// {@template conditionsuninitialized}
+/// State when available conditions have yet to be generated.
+/// This will generally happen if the source bloc has not yet
+/// emitted a state containing items to process.
+/// {@endtemplate}
+class ConditionsUninitialized extends FilterConditionsState {
+  /// {@macro conditionsuninitialized}
+  const ConditionsUninitialized();
+
+  @override
+  List<Object> get props => ['Uninitialized'];
+}
+
+/// {@template filterconditionsstate}
+/// Base [FilterConditionsState] for extension.
+/// {@endtemplate}
+abstract class FilterConditionsState extends Equatable {
+  /// {@macro filterconditionsstate}
+  const FilterConditionsState();
 }

--- a/lib/src/filter_conditions/filter_conditions_state.dart
+++ b/lib/src/filter_conditions/filter_conditions_state.dart
@@ -24,9 +24,9 @@ class ConditionsInitialized extends FilterConditionsState {
 
   /// {@macro conditionsinitialized}
   const ConditionsInitialized({
-    @required this.availableConditions,
-    @required this.activeAndConditions,
-    @required this.activeOrConditions,
+    required this.availableConditions,
+    required this.activeAndConditions,
+    required this.activeOrConditions,
   });
 
   @override

--- a/lib/src/item_list/item_list_bloc.dart
+++ b/lib/src/item_list/item_list_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:meta/meta.dart';
 
 import '../filter_conditions/filter_conditions_bloc.dart';
 import '../item_source.dart';
@@ -32,20 +31,17 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
   final Bloc _sourceBloc;
   final List<String> _searchProperties;
 
-  StreamSubscription _filterConditionsSubscription;
-  StreamSubscription _searchQuerySubscription;
-  StreamSubscription _sourceSubscription;
+  late StreamSubscription _filterConditionsSubscription;
+  late StreamSubscription _searchQuerySubscription;
+  late StreamSubscription _sourceSubscription;
 
   /// {@macro itemlistbloc}
   ItemListBloc({
-    @required FilterConditionsBloc filterConditionsBloc,
-    @required SearchQueryCubit searchQueryCubit,
-    @required Bloc sourceBloc,
-    List<String> searchProperties,
-  })  : assert(filterConditionsBloc != null),
-        assert(searchQueryCubit != null),
-        assert(sourceBloc != null),
-        _filterConditionsBloc = filterConditionsBloc,
+    required FilterConditionsBloc filterConditionsBloc,
+    required SearchQueryCubit searchQueryCubit,
+    required Bloc sourceBloc,
+    List<String> searchProperties = const [],
+  })  : _filterConditionsBloc = filterConditionsBloc,
         _searchQueryCubit = searchQueryCubit,
         _sourceBloc = sourceBloc,
         _searchProperties = searchProperties,
@@ -68,8 +64,7 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
         return emit(const NoSourceItems());
       }
 
-      final items = (_sourceBloc.state as T).items;
-      final filterResults = _filterSource(items);
+      final filterResults = _filterSource(_sourceBloc.state.items);
       final searchResults =
           _searchSource(_searchQueryCubit.state, filterResults);
 
@@ -81,9 +76,9 @@ class ItemListBloc<I extends ItemClassWithAccessor, T extends ItemSourceState>
 
   @override
   Future<void> close() async {
-    await _filterConditionsSubscription?.cancel();
-    await _searchQuerySubscription?.cancel();
-    await _sourceSubscription?.cancel();
+    await _filterConditionsSubscription.cancel();
+    await _searchQuerySubscription.cancel();
+    await _sourceSubscription.cancel();
 
     return super.close();
   }

--- a/lib/src/item_list/item_list_state.dart
+++ b/lib/src/item_list/item_list_state.dart
@@ -1,26 +1,5 @@
 part of 'item_list_bloc.dart';
 
-/// {@template itemliststate}
-/// Base [FilterConditionsState] for extension.
-/// {@endtemplate}
-abstract class ItemListState extends Equatable {
-  /// {@macro itemliststate}
-  const ItemListState();
-}
-
-/// {@template nosourceitems}
-/// State corresponding to no items received from the source bloc.
-///
-/// This state should be used to present an empty state to the user.
-/// {@endtemplate}
-class NoSourceItems extends ItemListState {
-  /// {@macro nosourceitems}
-  const NoSourceItems();
-
-  @override
-  List<Object> get props => ['Empty Source'];
-}
-
 /// {@template itemsemptystate}
 /// State corresponding to no items matching
 /// the active conditions or search query.
@@ -33,6 +12,14 @@ class ItemEmptyState extends ItemListState {
 
   @override
   List<Object> get props => ['No Results'];
+}
+
+/// {@template itemliststate}
+/// Base [FilterConditionsState] for extension.
+/// {@endtemplate}
+abstract class ItemListState extends Equatable {
+  /// {@macro itemliststate}
+  const ItemListState();
 }
 
 /// {@template itemresults}
@@ -50,4 +37,17 @@ class ItemResults<I extends ItemClassWithAccessor> extends ItemListState {
 
   @override
   List<Object> get props => [items];
+}
+
+/// {@template nosourceitems}
+/// State corresponding to no items received from the source bloc.
+///
+/// This state should be used to present an empty state to the user.
+/// {@endtemplate}
+class NoSourceItems extends ItemListState {
+  /// {@macro nosourceitems}
+  const NoSourceItems();
+
+  @override
+  List<Object> get props => ['Empty Source'];
 }

--- a/lib/src/list_manager.dart
+++ b/lib/src/list_manager.dart
@@ -69,13 +69,15 @@ class ListManager<I extends ItemClassWithAccessor, T extends ItemSourceState,
   final B sourceBloc;
 
   /// {@macro listmanager}
-  ListManager({
+  const ListManager({
     @required this.child,
     @required this.filterProperties,
     this.searchProperties,
     this.sourceBloc,
+    Key key,
   })  : assert(child != null),
-        assert(filterProperties != null);
+        assert(filterProperties != null),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/list_manager.dart
+++ b/lib/src/list_manager.dart
@@ -1,7 +1,5 @@
-import 'package:bloc/bloc.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:meta/meta.dart';
 
 import '../flutter_bloc_list_manager.dart';
 
@@ -81,7 +79,7 @@ class ListManager<I extends ItemClassWithAccessor, T extends ItemSourceState,
 
   @override
   Widget build(BuildContext context) {
-    final _sourceBloc = sourceBloc ?? context.bloc<B>();
+    final _sourceBloc = sourceBloc ?? context.read<B>();
 
     return MultiBlocProvider(
       providers: [
@@ -97,8 +95,8 @@ class ListManager<I extends ItemClassWithAccessor, T extends ItemSourceState,
         BlocProvider<ItemListBloc>(
           create: (context) => ItemListBloc<I, T>(
             sourceBloc: _sourceBloc,
-            filterConditionsBloc: context.bloc<FilterConditionsBloc>(),
-            searchQueryCubit: context.bloc<SearchQueryCubit>(),
+            filterConditionsBloc: context.read<FilterConditionsBloc>(),
+            searchQueryCubit: context.read<SearchQueryCubit>(),
             searchProperties: searchProperties,
           ),
         )

--- a/lib/src/list_manager.dart
+++ b/lib/src/list_manager.dart
@@ -56,6 +56,10 @@ class ListManager<I extends ItemClassWithAccessor, T extends ItemSourceState,
   /// of the blocs created by this widget to manage your list.
   final Widget child;
 
+  /// [Bloc] that will contain an [ItemSourceState]. If one is not provided
+  /// the current [BuildContext] will be used to look it up.
+  final B? sourceBloc;
+
   /// A [List] of property keys that should be used
   /// by the [FilterConditionsBloc] when generating available conditions.
   final List<String> filterProperties;
@@ -64,20 +68,14 @@ class ListManager<I extends ItemClassWithAccessor, T extends ItemSourceState,
   /// by the [ItemListBloc] while searching against the active query.
   final List<String> searchProperties;
 
-  /// [Bloc] that will contain an [ItemSourceState]. If one is not provided
-  /// the current [BuildContext] will be used to look it up.
-  final B sourceBloc;
-
   /// {@macro listmanager}
   const ListManager({
-    @required this.child,
-    @required this.filterProperties,
-    this.searchProperties,
+    required this.child,
     this.sourceBloc,
-    Key key,
-  })  : assert(child != null),
-        assert(filterProperties != null),
-        super(key: key);
+    this.filterProperties = const [],
+    this.searchProperties = const [],
+    Key? key,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,6 +1,6 @@
 /// Combines the give [property] and [value] into a storage key
 /// (`$property::$value`) to track active conditions.
-String generateConditionKey(String property, String value) {
+String generateConditionKey(String property, String? value) {
   return '$property::$value';
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,112 +7,182 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "31.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.4"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.13"
+    version: "2.8.0"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.0"
+    version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.8.2"
   bloc:
     dependency: "direct main"
     description:
       name: bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "8.0.2"
   bloc_test:
     dependency: "direct dev"
     description:
       name: bloc_test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "9.0.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.1.4"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.3.1"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.5"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.15.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.9"
+    version: "1.0.3"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.4"
-  csslib:
+    version: "3.0.1"
+  dart_style:
     dependency: transitive
     description:
-      name: csslib
+      name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "2.2.1"
+  diff_match_patch:
+    dependency: transitive
+    description:
+      name: diff_match_patch
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.1"
   effective_dart:
     dependency: "direct dev"
     description:
       name: effective_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.2"
   equatable:
     dependency: "direct main"
     description:
       name: equatable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "2.0.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -124,360 +194,311 @@ packages:
       name: flutter_bloc
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "8.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
-  http:
-    dependency: transitive
-    description:
-      name: http
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.0+4"
+    version: "2.0.2"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.3"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.12"
+    version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3"
+    version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.4"
+    version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.11"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "1.0.1"
   mockito:
     dependency: "direct dev"
     description:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
-  multi_server_socket:
+    version: "5.0.17"
+  mocktail:
     dependency: transitive
     description:
-      name: multi_server_socket
+      name: mocktail
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "0.2.0"
   nested:
     dependency: transitive
     description:
       name: nested
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
-  node_interop:
-    dependency: transitive
-    description:
-      name: node_interop
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.3"
-  node_io:
-    dependency: transitive
-    description:
-      name: node_io
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.1+2"
+    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.1"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
+    version: "2.0.2"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
+    version: "1.11.1"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   provider:
     dependency: transitive
     description:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.3"
+    version: "6.0.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "2.1.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "1.2.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "1.0.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test:
     dependency: transitive
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.4"
+    version: "1.17.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.4.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "7.5.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.7+14"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.6.1"
+    version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "3.1.0"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.16.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -264,7 +264,7 @@ packages:
     source: hosted
     version: "0.12.11"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -50,27 +50,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  build:
-    dependency: transitive
-    description:
-      name: build
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.1"
-  built_collection:
-    dependency: transitive
-    description:
-      name: built_collection
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.1.1"
-  built_value:
-    dependency: transitive
-    description:
-      name: built_value
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "8.1.4"
   characters:
     dependency: transitive
     description:
@@ -99,13 +78,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "4.1.0"
   collection:
     dependency: transitive
     description:
@@ -134,13 +106,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
-  dart_style:
-    dependency: transitive
-    description:
-      name: dart_style
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.1"
   diff_match_patch:
     dependency: transitive
     description:
@@ -169,13 +134,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
-  fixnum:
-    dependency: transitive
-    description:
-      name: fixnum
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -277,13 +235,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
-  mockito:
-    dependency: "direct dev"
-    description:
-      name: mockito
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.0.17"
   mocktail:
     dependency: transitive
     description:
@@ -380,13 +331,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.2.1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -148,13 +148,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.1"
-  effective_dart:
-    dependency: "direct dev"
-    description:
-      name: effective_dart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.2"
   equatable:
     dependency: "direct main"
     description:
@@ -195,6 +188,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.1"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -242,6 +242,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   logging:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ description: >
 homepage: https://github.com/danahartweg/flutter_bloc_list_manager
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,7 +14,6 @@ dependencies:
   bloc: ^8.0.2
   equatable: ^2.0.3
   flutter_bloc: ^8.0.1
-  meta: ^1.7.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,4 +21,3 @@ dev_dependencies:
 
   bloc_test: ^9.0.2
   flutter_lints: ^1.0.4
-  mockito: ^5.0.17

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_bloc_list_manager
-version: 0.4.0
+version: 0.5.0
 description: >
   Extension to flutter_bloc that handles the underlying logic to filter and search list view data dynamically.
 homepage: https://github.com/danahartweg/flutter_bloc_list_manager

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
     sdk: flutter
 
   bloc_test: ^9.0.2
-  effective_dart: ^1.3.2
+  flutter_lints: ^1.0.4
   mockito: ^5.0.17

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,15 +11,15 @@ dependencies:
   flutter:
     sdk: flutter
 
-  bloc: ^6.0.0
-  equatable: ^1.1.0
-  flutter_bloc: ^6.0.0
-  meta: ^1.1.8
+  bloc: ^8.0.2
+  equatable: ^2.0.3
+  flutter_bloc: ^8.0.1
+  meta: ^1.7.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  bloc_test: ^7.0.0
-  effective_dart: ^1.2.0
-  mockito: ^4.1.1
+  bloc_test: ^9.0.2
+  effective_dart: ^1.3.2
+  mockito: ^5.0.17

--- a/test/filter_conditions_bloc_test.dart
+++ b/test/filter_conditions_bloc_test.dart
@@ -1,11 +1,9 @@
 import 'dart:async';
-import 'package:mockito/mockito.dart';
 
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
 import 'package:flutter_bloc_list_manager/src/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import './mocks.dart';
 
@@ -37,13 +35,11 @@ void main() {
       _sourceBloc = MockSourceBloc();
       _sourceStreamController = StreamController();
 
-      when(_sourceBloc.listen(any)).thenAnswer((invocation) {
-        return _sourceStreamController.stream.listen(invocation
-            .positionalArguments.first as Function(MockSourceBlocState));
-      });
+      whenListen(_sourceBloc, _sourceStreamController.stream);
     });
 
     tearDown(() {
+      _sourceBloc.close();
       _sourceStreamController.close();
     });
 
@@ -68,7 +64,7 @@ void main() {
             filterProperties: [],
           );
         },
-        expect: [],
+        expect: () => [],
       );
 
       blocTest<FilterConditionsBloc, FilterConditionsState>(
@@ -84,7 +80,7 @@ void main() {
             filterProperties: [],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -106,7 +102,7 @@ void main() {
             filterProperties: ['id', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -137,7 +133,7 @@ void main() {
             filterProperties: ['name', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -163,7 +159,7 @@ void main() {
             filterProperties: ['id', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -191,7 +187,7 @@ void main() {
             filterProperties: ['id', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -241,7 +237,7 @@ void main() {
           _sourceStreamController.add(MockSourceBlocClassItems([_mockItem2]));
           await Future.delayed(Duration());
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -317,7 +313,7 @@ void main() {
             filterProperties: ['id', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -343,7 +339,7 @@ void main() {
             filterProperties: ['id', 'extra'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -369,7 +365,7 @@ void main() {
             filterProperties: ['conditional'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -396,7 +392,7 @@ void main() {
             filterProperties: ['conditional'],
           );
         },
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
@@ -419,7 +415,7 @@ void main() {
           filterProperties: [],
         ),
         act: (bloc) => bloc.add(AddCondition(property: 'id', value: '123')),
-        expect: [ConditionsUninitialized()],
+        expect: () => [ConditionsUninitialized()],
       );
 
       blocTest<FilterConditionsBloc, FilterConditionsState>(
@@ -443,7 +439,7 @@ void main() {
           ..add(RemoveCondition(property: 'id', value: '456'))
           ..add(RemoveCondition(property: 'conditional', value: 'True'))
           ..add(RemoveCondition(property: 'extra', value: 'something')),
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {
@@ -557,7 +553,7 @@ void main() {
           ..add(AddCondition(property: 'extra', value: 'something'))
           ..add(RemoveCondition(property: 'extra', value: 'something'))
           ..add(RemoveCondition(property: 'id', value: '123')),
-        expect: [
+        expect: () => [
           ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {

--- a/test/filter_conditions_bloc_test.dart
+++ b/test/filter_conditions_bloc_test.dart
@@ -49,7 +49,7 @@ void main() {
         filterProperties: [],
       );
 
-      expect(bloc.state, ConditionsUninitialized());
+      expect(bloc.state, const ConditionsUninitialized());
     });
 
     group('available conditions', () {
@@ -57,7 +57,7 @@ void main() {
         'does not act on a source bloc state with no items',
         build: () {
           whenListen<MockSourceBlocState>(
-              _sourceBloc, Stream.value(MockSourceBlocNoItems()));
+              _sourceBloc, Stream.value(const MockSourceBlocNoItems()));
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
             sourceBloc: _sourceBloc,
@@ -72,7 +72,7 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(MockSourceBlocClassItems([_mockItem1])),
+            Stream.value(const MockSourceBlocClassItems([_mockItem1])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -81,7 +81,7 @@ void main() {
           );
         },
         expect: () => [
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {},
@@ -94,7 +94,7 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(MockSourceBlocClassItems([_mockItem1])),
+            Stream.value(const MockSourceBlocClassItems([_mockItem1])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -104,8 +104,8 @@ void main() {
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
@@ -119,7 +119,7 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(MockSourceBlocClassItems([
+            Stream.value(const MockSourceBlocClassItems([
               MockItemClass(
                 id: 'idValue',
                 name: '',
@@ -134,7 +134,7 @@ void main() {
           );
         },
         expect: () => [
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {
@@ -151,7 +151,7 @@ void main() {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
             Stream.value(
-                MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
+                const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -161,8 +161,8 @@ void main() {
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
               'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
@@ -177,8 +177,8 @@ void main() {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
             Stream.fromIterable([
-              MockSourceBlocClassItems([_mockItem1]),
-              MockSourceBlocClassItems([_mockItem2, _mockItem3])
+              const MockSourceBlocClassItems([_mockItem1]),
+              const MockSourceBlocClassItems([_mockItem2, _mockItem3])
             ]),
           );
 
@@ -189,16 +189,16 @@ void main() {
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
             },
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem2.id, _mockItem3.id],
               'extra': [_mockItem2.extra, _mockItem3.extra],
@@ -214,40 +214,40 @@ void main() {
           filterProperties: ['id', 'extra'],
         ),
         act: (bloc) async {
-          _sourceStreamController.add(MockSourceBlocClassItems([_mockItem1]));
-          await Future.delayed(Duration());
+          _sourceStreamController.add(const MockSourceBlocClassItems([_mockItem1]));
+          await Future.delayed(const Duration());
 
           bloc.add(AddCondition(property: 'id', value: _mockItem1.id));
-          await Future.delayed(Duration());
+          await Future.delayed(const Duration());
 
           bloc.add(AddCondition(
             property: 'id',
             value: _mockItem3.id,
             mode: FilterMode.and,
           ));
-          await Future.delayed(Duration());
+          await Future.delayed(const Duration());
 
-          _sourceStreamController.add(MockSourceBlocClassItems([
+          _sourceStreamController.add(const MockSourceBlocClassItems([
             _mockItem1,
             _mockItem2,
             _mockItem3,
           ]));
-          await Future.delayed(Duration());
+          await Future.delayed(const Duration());
 
-          _sourceStreamController.add(MockSourceBlocClassItems([_mockItem2]));
-          await Future.delayed(Duration());
+          _sourceStreamController.add(const MockSourceBlocClassItems([_mockItem2]));
+          await Future.delayed(const Duration());
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
               'extra': [_mockItem1.extra],
             },
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', _mockItem1.id),
             },
@@ -289,8 +289,8 @@ void main() {
             },
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem2.id],
               'extra': [_mockItem2.extra],
@@ -305,7 +305,7 @@ void main() {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
             Stream.value(
-                MockSourceBlocClassItems([_mockItem1, _mockItem1, _mockItem2])),
+                const MockSourceBlocClassItems([_mockItem1, _mockItem1, _mockItem2])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -315,8 +315,8 @@ void main() {
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id],
               'extra': [_mockItem1.extra, _mockItem2.extra],
@@ -331,7 +331,7 @@ void main() {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
             Stream.value(
-                MockSourceBlocClassItems([_mockItem3, _mockItem2, _mockItem1])),
+                const MockSourceBlocClassItems([_mockItem3, _mockItem2, _mockItem1])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -341,8 +341,8 @@ void main() {
         },
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
-            activeOrConditions: {},
+            activeAndConditions: const {},
+            activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
               'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
@@ -357,7 +357,7 @@ void main() {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
             Stream.value(
-                MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
+                const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -366,7 +366,7 @@ void main() {
           );
         },
         expect: () => [
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {
@@ -384,7 +384,7 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(MockSourceBlocClassItems([_mockItem1])),
+            Stream.value(const MockSourceBlocClassItems([_mockItem1])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -393,7 +393,7 @@ void main() {
           );
         },
         expect: () => [
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {
@@ -414,8 +414,8 @@ void main() {
           sourceBloc: _sourceBloc,
           filterProperties: [],
         ),
-        act: (bloc) => bloc.add(AddCondition(property: 'id', value: '123')),
-        expect: () => [ConditionsUninitialized()],
+        act: (bloc) => bloc.add(const AddCondition(property: 'id', value: '123')),
+        expect: () => [const ConditionsUninitialized()],
       );
 
       blocTest<FilterConditionsBloc, FilterConditionsState>(
@@ -423,59 +423,59 @@ void main() {
         build: () => FilterConditionsBloc<MockSourceBlocClassItems>(
           sourceBloc: _sourceBloc,
           filterProperties: [],
-        )..emit(ConditionsInitialized(
+        )..emit(const ConditionsInitialized(
             availableConditions: {},
             activeOrConditions: {},
             activeAndConditions: {},
           )),
         act: (bloc) => bloc
-          ..add(AddCondition(property: 'id', value: '123'))
-          ..add(AddCondition(property: 'extra', value: 'something'))
-          ..add(AddCondition(property: 'conditional', value: 'True'))
-          ..add(AddCondition(property: 'id', value: '456'))
-          ..add(AddCondition(property: 'conditional', value: 'False'))
-          ..add(RemoveCondition(property: 'id', value: '123'))
-          ..add(RemoveCondition(property: 'conditional', value: 'False'))
-          ..add(RemoveCondition(property: 'id', value: '456'))
-          ..add(RemoveCondition(property: 'conditional', value: 'True'))
-          ..add(RemoveCondition(property: 'extra', value: 'something')),
+          ..add(const AddCondition(property: 'id', value: '123'))
+          ..add(const AddCondition(property: 'extra', value: 'something'))
+          ..add(const AddCondition(property: 'conditional', value: 'True'))
+          ..add(const AddCondition(property: 'id', value: '456'))
+          ..add(const AddCondition(property: 'conditional', value: 'False'))
+          ..add(const RemoveCondition(property: 'id', value: '123'))
+          ..add(const RemoveCondition(property: 'conditional', value: 'False'))
+          ..add(const RemoveCondition(property: 'id', value: '456'))
+          ..add(const RemoveCondition(property: 'conditional', value: 'True'))
+          ..add(const RemoveCondition(property: 'extra', value: 'something')),
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('extra', 'something'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('id', '456'),
@@ -483,44 +483,44 @@ void main() {
               generateConditionKey('conditional', 'True'),
               generateConditionKey('conditional', 'False'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           // Conditions start to be removed.
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
               generateConditionKey('conditional', 'False'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '456'),
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('extra', 'something'),
               generateConditionKey('conditional', 'True'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('extra', 'something'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {},
@@ -533,48 +533,48 @@ void main() {
         build: () => FilterConditionsBloc<MockSourceBlocClassItems>(
           sourceBloc: _sourceBloc,
           filterProperties: [],
-        )..emit(ConditionsInitialized(
+        )..emit(const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {},
           )),
         act: (bloc) => bloc
-          ..add(AddCondition(property: 'id', value: '123'))
-          ..add(AddCondition(
+          ..add(const AddCondition(property: 'id', value: '123'))
+          ..add(const AddCondition(
             property: 'id',
             value: '123',
             mode: FilterMode.and,
           ))
-          ..add(AddCondition(
+          ..add(const AddCondition(
             property: 'extra',
             value: 'something',
             mode: FilterMode.and,
           ))
-          ..add(AddCondition(property: 'extra', value: 'something'))
-          ..add(RemoveCondition(property: 'extra', value: 'something'))
-          ..add(RemoveCondition(property: 'id', value: '123')),
+          ..add(const AddCondition(property: 'extra', value: 'something'))
+          ..add(const RemoveCondition(property: 'extra', value: 'something'))
+          ..add(const RemoveCondition(property: 'id', value: '123')),
         expect: () => [
           ConditionsInitialized(
-            activeAndConditions: {},
+            activeAndConditions: const {},
             activeOrConditions: {
               generateConditionKey('id', '123'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
             activeAndConditions: {
               generateConditionKey('id', '123'),
             },
-            activeOrConditions: {},
-            availableConditions: {},
+            activeOrConditions: const {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
             activeAndConditions: {
               generateConditionKey('id', '123'),
               generateConditionKey('extra', 'something'),
             },
-            activeOrConditions: {},
-            availableConditions: {},
+            activeOrConditions: const {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
             activeAndConditions: {
@@ -583,16 +583,16 @@ void main() {
             activeOrConditions: {
               generateConditionKey('extra', 'something'),
             },
-            availableConditions: {},
+            availableConditions: const {},
           ),
           ConditionsInitialized(
             activeAndConditions: {
               generateConditionKey('id', '123'),
             },
-            activeOrConditions: {},
-            availableConditions: {},
+            activeOrConditions: const {},
+            availableConditions: const {},
           ),
-          ConditionsInitialized(
+          const ConditionsInitialized(
             activeAndConditions: {},
             activeOrConditions: {},
             availableConditions: {},
@@ -605,7 +605,7 @@ void main() {
       final bloc = FilterConditionsBloc(
         sourceBloc: _sourceBloc,
         filterProperties: [],
-      )..emit(ConditionsInitialized(
+      )..emit(const ConditionsInitialized(
           activeAndConditions: {},
           activeOrConditions: {},
           availableConditions: {},
@@ -613,33 +613,33 @@ void main() {
 
       expect(bloc.isConditionActive('nothing', 'here'), false);
 
-      bloc.add(AddCondition(
+      bloc.add(const AddCondition(
         property: 'id',
         value: '123',
       ));
-      await Future.delayed(Duration());
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('id', '123'), true);
 
-      bloc.add(AddCondition(
+      bloc.add(const AddCondition(
         property: 'extra',
         value: 'something',
         mode: FilterMode.and,
       ));
-      await Future.delayed(Duration());
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('extra', 'something'), true);
 
-      bloc.add(RemoveCondition(
+      bloc.add(const RemoveCondition(
         property: 'id',
         value: '123',
       ));
-      await Future.delayed(Duration());
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('id', '123'), false);
 
-      bloc.add(RemoveCondition(
+      bloc.add(const RemoveCondition(
         property: 'extra',
         value: 'something',
       ));
-      await Future.delayed(Duration());
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('extra', 'something'), false);
     });
 
@@ -647,26 +647,26 @@ void main() {
       final bloc = FilterConditionsBloc(
         sourceBloc: _sourceBloc,
         filterProperties: [],
-      )..emit(ConditionsInitialized(
+      )..emit(const ConditionsInitialized(
           activeAndConditions: {},
           activeOrConditions: {},
           availableConditions: {},
         ));
 
-      bloc.add(AddCondition(
+      bloc.add(const AddCondition(
         property: 'id',
         value: '123',
       ));
-      await Future.delayed(Duration());
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('id', '123'), true);
 
-      _sourceStreamController.add(MockSourceBlocClassItems([]));
-      await Future.delayed(Duration());
+      _sourceStreamController.add(const MockSourceBlocClassItems([]));
+      await Future.delayed(const Duration());
       expect(bloc.isConditionActive('id', '123'), false);
     });
 
     test('closes the source bloc subscription', () {
-      final stream = Stream.value(MockSourceBlocNoItems()).asBroadcastStream();
+      final stream = Stream.value(const MockSourceBlocNoItems()).asBroadcastStream();
       final onDoneCallback = expectAsync0(() {});
 
       whenListen<MockSourceBlocState>(_sourceBloc, stream);

--- a/test/filter_conditions_bloc_test.dart
+++ b/test/filter_conditions_bloc_test.dart
@@ -28,8 +28,8 @@ void main() {
   );
 
   group('FilterConditionsBloc', () {
-    MockSourceBloc _sourceBloc;
-    StreamController<MockSourceBlocState> _sourceStreamController;
+    late MockSourceBloc _sourceBloc;
+    late StreamController<MockSourceBlocState> _sourceStreamController;
 
     setUp(() {
       _sourceBloc = MockSourceBloc();
@@ -108,7 +108,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
-              'extra': [_mockItem1.extra],
+              'extra': [_mockItem1.extra!],
             },
           )
         ],
@@ -150,8 +150,8 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(
-                const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
+            Stream.value(const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -165,7 +165,11 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
-              'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
+              'extra': [
+                _mockItem1.extra!,
+                _mockItem2.extra!,
+                _mockItem3.extra!
+              ],
             },
           )
         ],
@@ -193,7 +197,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
-              'extra': [_mockItem1.extra],
+              'extra': [_mockItem1.extra!],
             },
           ),
           ConditionsInitialized(
@@ -201,7 +205,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem2.id, _mockItem3.id],
-              'extra': [_mockItem2.extra, _mockItem3.extra],
+              'extra': [_mockItem2.extra!, _mockItem3.extra!],
             },
           )
         ],
@@ -214,7 +218,8 @@ void main() {
           filterProperties: ['id', 'extra'],
         ),
         act: (bloc) async {
-          _sourceStreamController.add(const MockSourceBlocClassItems([_mockItem1]));
+          _sourceStreamController
+              .add(const MockSourceBlocClassItems([_mockItem1]));
           await Future.delayed(const Duration());
 
           bloc.add(AddCondition(property: 'id', value: _mockItem1.id));
@@ -234,7 +239,8 @@ void main() {
           ]));
           await Future.delayed(const Duration());
 
-          _sourceStreamController.add(const MockSourceBlocClassItems([_mockItem2]));
+          _sourceStreamController
+              .add(const MockSourceBlocClassItems([_mockItem2]));
           await Future.delayed(const Duration());
         },
         expect: () => [
@@ -243,7 +249,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id],
-              'extra': [_mockItem1.extra],
+              'extra': [_mockItem1.extra!],
             },
           ),
           ConditionsInitialized(
@@ -253,7 +259,7 @@ void main() {
             },
             availableConditions: {
               'id': [_mockItem1.id],
-              'extra': [_mockItem1.extra],
+              'extra': [_mockItem1.extra!],
             },
           ),
           ConditionsInitialized(
@@ -265,7 +271,7 @@ void main() {
             },
             availableConditions: {
               'id': [_mockItem1.id],
-              'extra': [_mockItem1.extra],
+              'extra': [_mockItem1.extra!],
             },
           ),
           ConditionsInitialized(
@@ -282,9 +288,9 @@ void main() {
                 _mockItem3.id,
               ],
               'extra': [
-                _mockItem1.extra,
-                _mockItem2.extra,
-                _mockItem3.extra,
+                _mockItem1.extra!,
+                _mockItem2.extra!,
+                _mockItem3.extra!,
               ],
             },
           ),
@@ -293,7 +299,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem2.id],
-              'extra': [_mockItem2.extra],
+              'extra': [_mockItem2.extra!],
             },
           )
         ],
@@ -304,8 +310,8 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(
-                const MockSourceBlocClassItems([_mockItem1, _mockItem1, _mockItem2])),
+            Stream.value(const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem1, _mockItem2])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -319,7 +325,7 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id],
-              'extra': [_mockItem1.extra, _mockItem2.extra],
+              'extra': [_mockItem1.extra!, _mockItem2.extra!],
             },
           )
         ],
@@ -330,8 +336,8 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(
-                const MockSourceBlocClassItems([_mockItem3, _mockItem2, _mockItem1])),
+            Stream.value(const MockSourceBlocClassItems(
+                [_mockItem3, _mockItem2, _mockItem1])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -345,7 +351,11 @@ void main() {
             activeOrConditions: const {},
             availableConditions: {
               'id': [_mockItem1.id, _mockItem2.id, _mockItem3.id],
-              'extra': [_mockItem1.extra, _mockItem2.extra, _mockItem3.extra],
+              'extra': [
+                _mockItem1.extra!,
+                _mockItem2.extra!,
+                _mockItem3.extra!
+              ],
             },
           )
         ],
@@ -356,8 +366,8 @@ void main() {
         build: () {
           whenListen<MockSourceBlocState>(
             _sourceBloc,
-            Stream.value(
-                const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3])),
+            Stream.value(const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3])),
           );
 
           return FilterConditionsBloc<MockSourceBlocClassItems>(
@@ -414,7 +424,8 @@ void main() {
           sourceBloc: _sourceBloc,
           filterProperties: [],
         ),
-        act: (bloc) => bloc.add(const AddCondition(property: 'id', value: '123')),
+        act: (bloc) =>
+            bloc.add(const AddCondition(property: 'id', value: '123')),
         expect: () => [const ConditionsUninitialized()],
       );
 
@@ -666,7 +677,8 @@ void main() {
     });
 
     test('closes the source bloc subscription', () {
-      final stream = Stream.value(const MockSourceBlocNoItems()).asBroadcastStream();
+      final stream =
+          Stream.value(const MockSourceBlocNoItems()).asBroadcastStream();
       final onDoneCallback = expectAsync0(() {});
 
       whenListen<MockSourceBlocState>(_sourceBloc, stream);

--- a/test/item_list_bloc_test.dart
+++ b/test/item_list_bloc_test.dart
@@ -1,15 +1,15 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
 import 'package:flutter_bloc_list_manager/src/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import './mocks.dart';
 
-class MockFilterConditionsBloc extends MockBloc<FilterConditionsState>
+class MockFilterConditionsBloc
+    extends MockBloc<FilterConditionsEvent, FilterConditionsState>
     implements FilterConditionsBloc {}
 
-class MockSearchQueryCubit extends MockBloc<String>
+class MockSearchQueryCubit extends MockCubit<String>
     implements SearchQueryCubit {}
 
 void main() {
@@ -46,6 +46,12 @@ void main() {
       _sourceBloc = MockSourceBloc();
     });
 
+    tearDown(() {
+      _filterConditionsBloc.close();
+      _searchQueryCubit.close();
+      _sourceBloc.close();
+    });
+
     test('sets an initial state', () {
       final bloc = ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
         filterConditionsBloc: _filterConditionsBloc,
@@ -71,7 +77,7 @@ void main() {
         );
       },
       skip: 1,
-      expect: [],
+      expect: () => [],
     );
 
     blocTest<ItemListBloc, ItemListState>(
@@ -96,7 +102,7 @@ void main() {
         );
       },
       skip: 1,
-      expect: [],
+      expect: () => [],
     );
 
     blocTest<ItemListBloc, ItemListState>(
@@ -124,7 +130,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1]),
       ],
     );
@@ -158,7 +164,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemEmptyState(),
       ],
     );
@@ -193,7 +199,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1, _mockItem3]),
       ],
     );
@@ -229,7 +235,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemEmptyState(),
       ],
     );
@@ -264,7 +270,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1]),
       ],
     );
@@ -301,7 +307,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1]),
       ],
     );
@@ -335,7 +341,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1, _mockItem3]),
       ],
     );
@@ -370,7 +376,7 @@ void main() {
           sourceBloc: _sourceBloc,
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem1, _mockItem3]),
       ],
     );
@@ -403,7 +409,7 @@ void main() {
           searchProperties: ['extra'],
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem2]),
       ],
     );
@@ -440,7 +446,7 @@ void main() {
           searchProperties: ['extra'],
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem2]),
       ],
     );
@@ -480,7 +486,7 @@ void main() {
           searchProperties: ['extra'],
         );
       },
-      expect: [
+      expect: () => [
         ItemResults([_mockItem2]),
       ],
     );
@@ -517,7 +523,7 @@ void main() {
           searchProperties: ['extra'],
         );
       },
-      expect: [
+      expect: () => [
         ItemEmptyState(),
       ],
     );

--- a/test/item_list_bloc_test.dart
+++ b/test/item_list_bloc_test.dart
@@ -29,9 +29,9 @@ void main() {
   );
 
   group('ItemListBloc', () {
-    MockFilterConditionsBloc _filterConditionsBloc;
-    MockSearchQueryCubit _searchQueryCubit;
-    MockSourceBloc _sourceBloc;
+    late MockFilterConditionsBloc _filterConditionsBloc;
+    late MockSearchQueryCubit _searchQueryCubit;
+    late MockSourceBloc _sourceBloc;
 
     setUp(() {
       _filterConditionsBloc = MockFilterConditionsBloc();
@@ -58,35 +58,17 @@ void main() {
     blocTest<ItemListBloc, ItemListState>(
       'requires initialized filter conditions',
       build: () {
+        whenListen<FilterConditionsState>(
+          _filterConditionsBloc,
+          Stream.value(
+            const ConditionsUninitialized(),
+          ),
+        );
+
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(const MockSourceBlocClassItems([_mockItem1])),
         );
-
-        return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
-          filterConditionsBloc: _filterConditionsBloc,
-          searchQueryCubit: _searchQueryCubit,
-          sourceBloc: _sourceBloc,
-        );
-      },
-      skip: 1,
-      expect: () => [],
-    );
-
-    blocTest<ItemListBloc, ItemListState>(
-      'requires a source bloc state with items',
-      build: () {
-        whenListen<FilterConditionsState>(
-          _filterConditionsBloc,
-          Stream.value(
-            const ConditionsInitialized(
-              activeAndConditions: {},
-              activeOrConditions: {},
-              availableConditions: {},
-            ),
-          ),
-        );
-        whenListen<String>(_searchQueryCubit, Stream.value(''));
 
         return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
           filterConditionsBloc: _filterConditionsBloc,
@@ -147,7 +129,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -182,7 +165,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -218,7 +202,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -253,7 +238,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -290,7 +276,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -324,7 +311,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -359,7 +347,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -391,7 +380,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -428,7 +418,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -468,7 +459,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -505,7 +497,8 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems(
+                [_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 

--- a/test/item_list_bloc_test.dart
+++ b/test/item_list_bloc_test.dart
@@ -5,13 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 
 import './mocks.dart';
 
-class MockFilterConditionsBloc
-    extends MockBloc<FilterConditionsEvent, FilterConditionsState>
-    implements FilterConditionsBloc {}
-
-class MockSearchQueryCubit extends MockCubit<String>
-    implements SearchQueryCubit {}
-
 void main() {
   const _mockItem1 = MockItemClass(
     id: 'idValue1',
@@ -59,7 +52,7 @@ void main() {
         sourceBloc: _sourceBloc,
       );
 
-      expect(bloc.state, NoSourceItems());
+      expect(bloc.state, const NoSourceItems());
     });
 
     blocTest<ItemListBloc, ItemListState>(
@@ -67,7 +60,7 @@ void main() {
       build: () {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
-          Stream.value(MockSourceBlocClassItems([_mockItem1])),
+          Stream.value(const MockSourceBlocClassItems([_mockItem1])),
         );
 
         return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
@@ -86,7 +79,7 @@ void main() {
         whenListen<FilterConditionsState>(
           _filterConditionsBloc,
           Stream.value(
-            ConditionsInitialized(
+            const ConditionsInitialized(
               activeAndConditions: {},
               activeOrConditions: {},
               availableConditions: {},
@@ -111,7 +104,7 @@ void main() {
         whenListen<FilterConditionsState>(
           _filterConditionsBloc,
           Stream.value(
-            ConditionsInitialized(
+            const ConditionsInitialized(
               activeAndConditions: {},
               activeOrConditions: {},
               availableConditions: {},
@@ -121,7 +114,7 @@ void main() {
         whenListen<String>(_searchQueryCubit, Stream.value(''));
         whenListen<MockSourceBlocState>(
           _sourceBloc,
-          Stream.value(MockSourceBlocClassItems([_mockItem1])),
+          Stream.value(const MockSourceBlocClassItems([_mockItem1])),
         );
 
         return ItemListBloc<MockItemClass, MockSourceBlocClassItems>(
@@ -131,7 +124,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1]),
+        const ItemResults([_mockItem1]),
       ],
     );
 
@@ -142,11 +135,11 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('id', '123'),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -154,7 +147,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -165,7 +158,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemEmptyState(),
+        const ItemEmptyState(),
       ],
     );
 
@@ -176,12 +169,12 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem3.id),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -189,7 +182,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -200,7 +193,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1, _mockItem3]),
+        const ItemResults([_mockItem1, _mockItem3]),
       ],
     );
 
@@ -216,8 +209,8 @@ void main() {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('name', 'bogus name'),
               },
-              activeOrConditions: {},
-              availableConditions: {},
+              activeOrConditions: const {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -225,7 +218,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -236,7 +229,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemEmptyState(),
+        const ItemEmptyState(),
       ],
     );
 
@@ -251,8 +244,8 @@ void main() {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('common', _mockItem2.common),
               },
-              activeOrConditions: {},
-              availableConditions: {},
+              activeOrConditions: const {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -260,7 +253,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -271,7 +264,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1]),
+        const ItemResults([_mockItem1]),
       ],
     );
 
@@ -289,7 +282,7 @@ void main() {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem3.id),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -297,7 +290,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -308,7 +301,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1]),
+        const ItemResults([_mockItem1]),
       ],
     );
 
@@ -319,11 +312,11 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('conditional', 'True'),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -331,7 +324,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -342,7 +335,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1, _mockItem3]),
+        const ItemResults([_mockItem1, _mockItem3]),
       ],
     );
 
@@ -353,12 +346,12 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('conditional', 'True'),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -366,7 +359,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -377,7 +370,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem1, _mockItem3]),
+        const ItemResults([_mockItem1, _mockItem3]),
       ],
     );
 
@@ -387,7 +380,7 @@ void main() {
         whenListen<FilterConditionsState>(
           _filterConditionsBloc,
           Stream.value(
-            ConditionsInitialized(
+            const ConditionsInitialized(
               activeAndConditions: {},
               activeOrConditions: {},
               availableConditions: {},
@@ -398,7 +391,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -410,7 +403,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem2]),
+        const ItemResults([_mockItem2]),
       ],
     );
 
@@ -421,13 +414,13 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem2.id),
                 generateConditionKey('id', _mockItem3.id),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -435,7 +428,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -447,7 +440,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem2]),
+        const ItemResults([_mockItem2]),
       ],
     );
 
@@ -467,7 +460,7 @@ void main() {
                 generateConditionKey('id', _mockItem2.id),
                 generateConditionKey('id', _mockItem3.id),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -475,7 +468,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -487,7 +480,7 @@ void main() {
         );
       },
       expect: () => [
-        ItemResults([_mockItem2]),
+        const ItemResults([_mockItem2]),
       ],
     );
 
@@ -498,13 +491,13 @@ void main() {
           _filterConditionsBloc,
           Stream.value(
             ConditionsInitialized(
-              activeAndConditions: {},
+              activeAndConditions: const {},
               activeOrConditions: {
                 generateConditionKey('id', _mockItem1.id),
                 generateConditionKey('id', _mockItem2.id),
                 generateConditionKey('id', _mockItem3.id),
               },
-              availableConditions: {},
+              availableConditions: const {},
             ),
           ),
         );
@@ -512,7 +505,7 @@ void main() {
         whenListen<MockSourceBlocState>(
           _sourceBloc,
           Stream.value(
-            MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
+            const MockSourceBlocClassItems([_mockItem1, _mockItem2, _mockItem3]),
           ),
         );
 
@@ -524,8 +517,15 @@ void main() {
         );
       },
       expect: () => [
-        ItemEmptyState(),
+        const ItemEmptyState(),
       ],
     );
   });
 }
+
+class MockFilterConditionsBloc
+    extends MockBloc<FilterConditionsEvent, FilterConditionsState>
+    implements FilterConditionsBloc {}
+
+class MockSearchQueryCubit extends MockCubit<String>
+    implements SearchQueryCubit {}

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,11 +1,12 @@
 import 'package:bloc/bloc.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:equatable/equatable.dart';
-
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
 
-class MockSourceBloc extends MockBloc<MockSourceBlocState>
-    implements Bloc<ItemSourceState, MockSourceBlocState> {}
+class MockSourceBloc extends MockBloc<MockSourceBlocEvent, MockSourceBlocState>
+    implements Bloc<MockSourceBlocEvent, MockSourceBlocState> {}
+
+class MockSourceBlocEvent {}
 
 abstract class MockSourceBlocState extends Equatable {
   const MockSourceBlocState();

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -3,22 +3,6 @@ import 'package:bloc_test/bloc_test.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
 
-class MockSourceBloc extends MockBloc<MockSourceBlocEvent, MockSourceBlocState>
-    implements Bloc<MockSourceBlocEvent, MockSourceBlocState> {}
-
-class MockSourceBlocEvent {}
-
-abstract class MockSourceBlocState extends Equatable {
-  const MockSourceBlocState();
-}
-
-class MockSourceBlocNoItems extends MockSourceBlocState {
-  const MockSourceBlocNoItems();
-
-  @override
-  List<Object> get props => ['No Items'];
-}
-
 class MockItemClass extends Equatable implements ItemClassWithAccessor {
   final String id;
   final String name;
@@ -34,6 +18,10 @@ class MockItemClass extends Equatable implements ItemClassWithAccessor {
     this.conditional,
   });
 
+  @override
+  List<Object> get props => [id, name, extra, common, conditional];
+
+  @override
   dynamic operator [](String prop) {
     switch (prop) {
       case 'id':
@@ -57,17 +45,31 @@ class MockItemClass extends Equatable implements ItemClassWithAccessor {
         );
     }
   }
-
-  @override
-  List<Object> get props => [id, name, extra, common, conditional];
 }
+
+class MockSourceBloc extends MockBloc<MockSourceBlocEvent, MockSourceBlocState>
+    implements Bloc<MockSourceBlocEvent, MockSourceBlocState> {}
 
 class MockSourceBlocClassItems extends MockSourceBlocState
     implements ItemSourceState<MockItemClass> {
+  @override
   final List<MockItemClass> items;
 
   const MockSourceBlocClassItems(this.items);
 
   @override
   List<Object> get props => [items];
+}
+
+class MockSourceBlocEvent {}
+
+class MockSourceBlocNoItems extends MockSourceBlocState {
+  const MockSourceBlocNoItems();
+
+  @override
+  List<Object> get props => ['No Items'];
+}
+
+abstract class MockSourceBlocState extends Equatable {
+  const MockSourceBlocState();
 }

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -6,39 +6,34 @@ import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
 class MockItemClass extends Equatable implements ItemClassWithAccessor {
   final String id;
   final String name;
-  final String extra;
-  final String common;
-  final bool conditional;
+  final String? extra;
+  final String? common;
+  final bool? conditional;
 
   const MockItemClass({
-    this.id,
-    this.name,
+    required this.id,
+    required this.name,
     this.extra,
     this.common,
     this.conditional,
   });
 
   @override
-  List<Object> get props => [id, name, extra, common, conditional];
+  List<Object?> get props => [id, name, extra, common, conditional];
 
   @override
   dynamic operator [](String prop) {
     switch (prop) {
       case 'id':
         return id;
-        break;
       case 'name':
         return name;
-        break;
       case 'extra':
         return extra;
-        break;
       case 'common':
         return common;
-        break;
       case 'conditional':
         return conditional;
-        break;
       default:
         throw ArgumentError(
           'Property `$prop` does not exist on PlantVarietyIndex.',

--- a/test/search_query_test.dart
+++ b/test/search_query_test.dart
@@ -1,7 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
-import 'package:flutter_test/flutter_test.dart';
-
 import 'package:flutter_bloc_list_manager/flutter_bloc_list_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('SearchQueryCubit', () {
@@ -18,14 +17,14 @@ void main() {
         ..setQuery('')
         ..setQuery('search2')
         ..clearQuery(),
-      expect: ['search1', '', 'search2', ''],
+      expect: () => ['search1', '', 'search2', ''],
     );
 
     blocTest<SearchQueryCubit, String>(
       'stores query state lowercase',
       build: () => SearchQueryCubit(),
       act: (cubit) => cubit.setQuery('ABC'),
-      expect: ['abc'],
+      expect: () => ['abc'],
     );
   });
 }


### PR DESCRIPTION
Everything should be using the latest bloc syntax as well as null safety. I also ran a formatting pass against the code to make sure things were as cleaned up as possible, especially since `effective_dart` is no longer a thing (replaced with `flutter_lints`).

Removed `mockito` as it was no longer needed, but if a testing library other than `bloc_test` is needed in the future, `mocktail` will be used instead.

Once this version is published, I'll also update the example file to match the latest conventions and package versions.

Will close #23 

### Changed
- **Breaking:** Converted to null safety.
- Bumped `bloc` to `^8.0.2`
- Bumped `equatable` to `^2.0.3`
- Bumped `flutter_bloc` to `^8.0.1`