### PR TITLE
Switch to credentialJson for publishing

### DIFF
--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -55,5 +55,4 @@ jobs:
         uses: k-paxian/dart-package-publisher@v1.2
         with:
           skipTests: true
-          accessToken: ${{ secrets.PUB_OAUTH_ACCESS_TOKEN }}
-          refreshToken: ${{ secrets.PUB_OAUTH_REFRESH_TOKEN }}
+          credentialJson: ${{ secrets.PUB_CREDENTIALS_JSON }}


### PR DESCRIPTION
Hopefully this contains the information needed to complete pub authorization as a verified publisher instead of just the access and refresh tokens.